### PR TITLE
cemerick.nrepl => clojure.tools.nrepl

### DIFF
--- a/ccw.core/META-INF/MANIFEST.MF
+++ b/ccw.core/META-INF/MANIFEST.MF
@@ -25,10 +25,10 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.help,
  ccw.branding;bundle-version="0.0.46",
  org.eclipse.ui.workbench.texteditor,
- nrepl-module;bundle-version="0.0.1",
  clojure.osgi,
  ccw.clojure;bundle-version="1.2.0",
- ccw.clojurecontrib;bundle-version="1.2.0"
+ ccw.clojurecontrib;bundle-version="1.2.0",
+ org.clojure.tools.nrepl;bundle-version="0.0.2"
 Bundle-ClassPath: .,
  classes/
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/ccw.core/src/ccw/CCWPlugin.java
+++ b/ccw.core/src/ccw/CCWPlugin.java
@@ -44,7 +44,7 @@ import ccw.preferences.SyntaxColoringPreferencePage;
 import ccw.repl.REPLView;
 import ccw.util.DisplayUtil;
 import ccw.utils.editors.antlrbased.IScanContext;
-import cemerick.nrepl.Connection;
+import clojure.tools.nrepl.Connection;
 import clojure.osgi.ClojureOSGi;
 
 /**

--- a/ccw.core/src/ccw/builder/ClojureBuilder.java
+++ b/ccw.core/src/ccw/builder/ClojureBuilder.java
@@ -35,7 +35,7 @@ import org.eclipse.jdt.core.JavaCore;
 import ccw.CCWPlugin;
 import ccw.launching.ClojureLaunchDelegate;
 import ccw.repl.REPLView;
-import cemerick.nrepl.Connection;
+import clojure.tools.nrepl.Connection;
 
 /*
  * gaetan.morice:

--- a/ccw.core/src/ccw/builder/ClojureVisitor.java
+++ b/ccw.core/src/ccw/builder/ClojureVisitor.java
@@ -31,8 +31,8 @@ import org.eclipse.ui.texteditor.MarkerUtilities;
 
 import ccw.CCWPlugin;
 import ccw.editors.antlrbased.CompileLibAction;
-import cemerick.nrepl.Connection;
-import cemerick.nrepl.Connection.Response;
+import clojure.tools.nrepl.Connection;
+import clojure.tools.nrepl.Connection.Response;
 
 
 public class ClojureVisitor implements IResourceVisitor {

--- a/ccw.core/src/ccw/editors/antlrbased/ClojureHyperlinkDetector.clj
+++ b/ccw.core/src/ccw/editors/antlrbased/ClojureHyperlinkDetector.clj
@@ -1,7 +1,7 @@
 (ns ccw.editors.antlrbased.ClojureHyperlinkDetector
   (:require [clojure.zip :as z]
             [paredit.loc-utils :as lu]
-            [cemerick.nrepl :as repl]
+            [clojure.tools.nrepl :as repl]
             [ccw.editors.antlrbased.ClojureHyperlink])
   (:use clojure.contrib.core)
   (:import 

--- a/ccw.core/src/ccw/editors/antlrbased/ClojureProposalProcessor.java
+++ b/ccw.core/src/ccw/editors/antlrbased/ClojureProposalProcessor.java
@@ -50,7 +50,7 @@ import org.eclipse.swt.graphics.TextStyle;
 import ccw.CCWPlugin;
 import ccw.outline.NamespaceBrowser;
 import ccw.util.ClojureDocUtils;
-import cemerick.nrepl.Connection;
+import clojure.tools.nrepl.Connection;
 
 public class ClojureProposalProcessor implements IContentAssistProcessor {
 	private static final int MAX_JAVA_SEARCH_RESULT_NUMBER = 50;

--- a/ccw.core/src/ccw/editors/antlrbased/OpenDeclarationAction.java
+++ b/ccw.core/src/ccw/editors/antlrbased/OpenDeclarationAction.java
@@ -18,7 +18,7 @@ import org.eclipse.ui.part.WorkbenchPart;
 
 import ccw.ClojureCore;
 import ccw.repl.REPLView;
-import cemerick.nrepl.Connection;
+import clojure.tools.nrepl.Connection;
 
 public class OpenDeclarationAction extends Action {
     public final static String ID = "OpenDeclarationAction"; //$NON-NLS-1$

--- a/ccw.core/src/ccw/editors/antlrbased/RunTestsAction.java
+++ b/ccw.core/src/ccw/editors/antlrbased/RunTestsAction.java
@@ -24,8 +24,8 @@ import clojure.lang.Keyword;
 
 import ccw.CCWPlugin;
 import ccw.repl.REPLView;
-import cemerick.nrepl.Connection;
-import cemerick.nrepl.Connection.Response;
+import clojure.tools.nrepl.Connection;
+import clojure.tools.nrepl.Connection.Response;
 
 public class RunTestsAction extends Action {
     public static final String RUN_TESTS_ID = "RunTestsAction";

--- a/ccw.core/src/ccw/launching/ClojureLaunchDelegate.java
+++ b/ccw.core/src/ccw/launching/ClojureLaunchDelegate.java
@@ -42,7 +42,7 @@ import ccw.ClojureCore;
 import ccw.ClojureProject;
 import ccw.repl.REPLView;
 import ccw.util.DisplayUtil;
-import cemerick.nrepl.SafeFn;
+import clojure.tools.nrepl.SafeFn;
 import clojure.lang.AFn;
 import clojure.lang.RT;
 import clojure.lang.Symbol;
@@ -56,7 +56,7 @@ public class ClojureLaunchDelegate extends JavaLaunchDelegate {
     private static ServerSocket ackREPLServer;
     static {
         try {
-            ackREPLServer = (ServerSocket)((List)Var.find(Symbol.intern("cemerick.nrepl/start-server")).invoke()).get(0);
+            ackREPLServer = (ServerSocket)((List)Var.find(Symbol.intern("clojure.tools.nrepl/start-server")).invoke()).get(0);
         } catch (Exception e) {
             CCWPlugin.logError("Could not start plugin-hosted REPL server for launch ack", e);
         }
@@ -80,7 +80,7 @@ public class ClojureLaunchDelegate extends JavaLaunchDelegate {
         public void done() {
             super.done();
             
-            final Integer port = (Integer)SafeFn.find("cemerick.nrepl", "wait-for-ack").sInvoke(10000);
+            final Integer port = (Integer)SafeFn.find("clojure.tools.nrepl", "wait-for-ack").sInvoke(10000);
             if (port == null) {
                 CCWPlugin.logError("Waiting for new REPL process ack timed out");
                 return;
@@ -106,7 +106,7 @@ public class ClojureLaunchDelegate extends JavaLaunchDelegate {
     public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor) throws CoreException {
         launch.setAttribute(LaunchUtils.ATTR_PROJECT_NAME, configuration.getAttribute(LaunchUtils.ATTR_PROJECT_NAME, (String) null));
         launch.setAttribute(LaunchUtils.ATTR_IS_AUTO_RELOAD_ENABLED, Boolean.toString(configuration.getAttribute(LaunchUtils.ATTR_IS_AUTO_RELOAD_ENABLED, false)));
-        SafeFn.find("cemerick.nrepl", "reset-ack-port!").sInvoke();
+        SafeFn.find("clojure.tools.nrepl", "reset-ack-port!").sInvoke();
         try {
             Var.pushThreadBindings(RT.map(currentLaunch, launch));
             super.launch(configuration, mode, launch, (monitor == null || !isLaunchREPL(configuration)) ?
@@ -141,9 +141,9 @@ public class ClojureLaunchDelegate extends JavaLaunchDelegate {
 				throw new WorkbenchException("Could not find ccw.debug.serverrepl source file", e);
 			}
 			
-			String nREPLInit = "(require 'cemerick.nrepl)" + 
+			String nREPLInit = "(require 'clojure.tools.nrepl)" + 
 			    // don't want start-server return value printed
-			    String.format("(do (cemerick.nrepl/start-server 0 %s) nil)", ackREPLServer.getLocalPort());
+			    String.format("(do (clojure.tools.nrepl/start-server 0 %s) nil)", ackREPLServer.getLocalPort());
 			
 			return String.format("-i \"%s\" -e \"%s\" %s %s", toolingFile, nREPLInit,
 			        filesToLaunchArguments, userProgramArguments);
@@ -188,7 +188,7 @@ public class ClojureLaunchDelegate extends JavaLaunchDelegate {
         }
         
         try {
-            File repllib = FileLocator.getBundleFile(Platform.getBundle("nrepl-module"));
+            File repllib = FileLocator.getBundleFile(Platform.getBundle("org.clojure.tools.nrepl"));
             classpath.add(repllib.getAbsolutePath());
         } catch (IOException e) {
             throw new WorkbenchException("Failed to find nrepl library", e);

--- a/ccw.core/src/ccw/outline/NamespaceBrowser.java
+++ b/ccw.core/src/ccw/outline/NamespaceBrowser.java
@@ -57,8 +57,8 @@ import ccw.launching.LaunchUtils;
 import ccw.preferences.PreferenceConstants;
 import ccw.util.ClojureDocUtils;
 import ccw.util.DisplayUtil;
-import cemerick.nrepl.Connection;
-import cemerick.nrepl.Connection.Response;
+import clojure.tools.nrepl.Connection;
+import clojure.tools.nrepl.Connection.Response;
 import clojure.lang.Keyword;
 
 public class NamespaceBrowser extends ViewPart implements ISelectionProvider, ISelectionChangedListener {

--- a/ccw.core/src/ccw/repl/REPLView.java
+++ b/ccw.core/src/ccw/repl/REPLView.java
@@ -39,7 +39,7 @@ import ccw.editors.antlrbased.IClojureEditorActionDefinitionIds;
 import ccw.editors.antlrbased.OpenDeclarationAction;
 import ccw.editors.rulesbased.ClojureDocumentProvider;
 import ccw.outline.NamespaceBrowser;
-import cemerick.nrepl.Connection;
+import clojure.tools.nrepl.Connection;
 import clojure.lang.Atom;
 import clojure.lang.PersistentTreeMap;
 import clojure.lang.Symbol;

--- a/ccw.core/src/ccw/repl/view_helpers.clj
+++ b/ccw.core/src/ccw/repl/view_helpers.clj
@@ -1,5 +1,5 @@
 (ns ccw.repl.view-helpers
-  (:require [cemerick.nrepl :as repl])
+  (:require [clojure.tools.nrepl :as repl])
   (:use clojure.contrib.def)
   (:import ccw.CCWPlugin
     org.eclipse.ui.PlatformUI


### PR DESCRIPTION
Laurent,

I struggled with OSGi / PDE / maven for some hours today, and didn't make much progress on that front unfortunately.  Here is a commit that begins to target 0.0.2-SNAPSHOT of clojure.tools.nrepl instead of cemerick.nrepl.  Builds of the latter are now going into Sonatype's snapshots repo (https://oss.sonatype.org/content/repositories/snapshots/org/clojure/), so you don't have to build it -- just add a MANIFEST.MF, and you should be good to go.

I'll start moving on the history and other items tonight.  If you're around tomorrow, any insight you might have on the OSGi / maven / PDE issues would be most helpful.  I pinged aav earlier, hopefully we can convince him to assist in some way as well.

Thanks,
- Chas 
