### PR TITLE
Fix package conflict with nrepl.el

### DIFF
--- a/ccw.core/src/clj/ccw/debug/serverrepl.clj
+++ b/ccw.core/src/clj/ccw/debug/serverrepl.clj
@@ -244,7 +244,7 @@
 
 ;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;
-(ns complete.core
+(ns ccw.complete
   (:require [clojure.main])
   (:import [java.util.jar JarFile] [java.io File])
   (:require [clojure.string :as s]))

--- a/ccw.core/src/clj/ccw/editors/clojure/clojure_proposal_processor.clj
+++ b/ccw.core/src/clj/ccw/editors/clojure/clojure_proposal_processor.clj
@@ -186,7 +186,7 @@
   "Create the complete command to be sent remotely to get back a list of
    completion proposals."
   [namespace prefix find-only-public]
-  (format (str "(complete.core/ccw-completions \"%s\" (clojure.core/the-ns '%s) %d)") 
+  (format (str "(ccw.complete/ccw-completions \"%s\" (clojure.core/the-ns '%s) %d)") 
           prefix
           namespace
           completion-limit))


### PR DESCRIPTION
complete.core package conflicts with released version of complete.core that is used by nrepl.el. Give the ccw version its own package name so we can use completion in both IDEs at the same time.
