### PR TITLE
Remove duplication in a namespace

### DIFF
--- a/ccw.core/src/clj/ccw/editors/clojure/clojure_proposal_processor.clj
+++ b/ccw.core/src/clj/ccw/editors/clojure/clojure_proposal_processor.clj
@@ -51,18 +51,6 @@
       (when (call? (z/node maybe-call-loc))
         maybe-call-loc))))
 
-(defn call-context-loc
-  "for viewer, at offset 12, return the loc containing the encapsulatin
-   call, or nil"
-  [viewer offset]
-  (when (pos? offset)
-    (let [loc (lu/loc-containing-offset 
-                (-> viewer .getParseState :parse-tree lu/parsed-root-loc)
-                offset)
-          maybe-call-loc (-?> loc parent-call)]
-      (when (-?> maybe-call-loc z/node call?)
-        maybe-call-loc))))
-
 (defn call-symbol
   "for viewer, at offset 12, return the symbol name if the offset
    is inside a function/macro call, or nil"


### PR DESCRIPTION
I saw a couple bits duplicated and didn't think they needed to.  One import duplicated, another entire `defn`.
