### PR TITLE
the nREPL server being an Agent was always a private impl detail, fixes gc-405

### DIFF
--- a/ccw.core/src/java/ccw/CCWPlugin.java
+++ b/ccw.core/src/java/ccw/CCWPlugin.java
@@ -50,7 +50,6 @@ import ccw.preferences.SyntaxColoringPreferencePage;
 import ccw.repl.REPLView;
 import ccw.util.BundleUtils;
 import ccw.util.DisplayUtil;
-import clojure.lang.Agent;
 import clojure.lang.Keyword;
 import clojure.lang.Var;
 import clojure.osgi.ClojureOSGi;
@@ -95,7 +94,7 @@ public class CCWPlugin extends AbstractUIPlugin {
 	        	Object handler = BundleUtils.requireAndGetVar(
 	        	        getBundle().getSymbolicName(),
 	        	        "clojure.tools.nrepl.ack/handle-ack").invoke(defaultHandler);
-	            ackREPLServer = (ServerSocket)((Map)((Agent)startServer.invoke(Keyword.intern("handler"), handler)).deref()).get(Keyword.intern("ss"));
+	            ackREPLServer = (ServerSocket)((Map)startServer.invoke(Keyword.intern("handler"), handler)).get(Keyword.intern("server-socket"));
 	            CCWPlugin.log("Started ccw nREPL server: nrepl://localhost:" + ackREPLServer.getLocalPort());
 	        } catch (Exception e) {
 	            CCWPlugin.logError("Could not start plugin-hosted REPL server", e);


### PR DESCRIPTION
This requires nREPL >= 0.2.0-beta10, available for now in SNAPSHOT form here:

https://oss.sonatype.org/content/repositories/snapshots//org/clojure/tools.nrepl/0.2.0-SNAPSHOT/tools.nrepl-0.2.0-20121003.190640-43.jar
