### PR TITLE
Stop sending broken code when printing stack traces in the REPL

### DIFF
--- a/ccw.core/src/java/ccw/repl/REPLView.java
+++ b/ccw.core/src/java/ccw/repl/REPLView.java
@@ -259,7 +259,13 @@ public class REPLView extends ViewPart implements IAdaptable {
     }
 
     public void printErrorDetail() {
-        evalExpression("(binding [*out* *err*] (if-not *e (println \"No prior exception bound to *e.\") (require 'clojure.repl) (clojure.repl/pst *e)))", false, false);
+        evalExpression("(require 'clojure.repl)" +
+        		"(binding [*out* *err*]" +
+        		"  (if-not *e (println \"No prior exception bound to *e.\")" +
+        		// concession for Clojure 1.2.0 environments that don't have pst
+        		"    (if-let [pst (resolve 'clojure.repl/pst)]" +
+        		"      (pst *e)" +
+        		"      (.printStackTrace *e *out*))))", false, false);
     }
 
     public void sendInterrupt() {


### PR DESCRIPTION
Fixed poor change I made in b39465c2aca5a0d12320194d91ae935d0cb2add1.  Should be released post-haste, as that commit broke stack trace printing entirely.
