### PR TITLE
Avoid NPE in ClojureLaunchShortcut

### DIFF
--- a/ccw.core/src/java/ccw/launching/ClojureLaunchShortcut.java
+++ b/ccw.core/src/java/ccw/launching/ClojureLaunchShortcut.java
@@ -126,7 +126,9 @@ public class ClojureLaunchShortcut implements ILaunchShortcut, IJavaLaunchConfig
     			launchProject(project, filesToLaunch, mode);
     		} else {
     			IViewPart replView = CCWPlugin.getDefault().getProjectREPL(project);
-    			replView.getViewSite().getPage().activate(replView);
+    			if (replView != null) {
+    				replView.getViewSite().getPage().activate(replView);
+    			}
     		}
     	}
     }    


### PR DESCRIPTION
REPL view can be missing.

(At all other call sites result of getProjectREPL call
is checked for null anyway.)
