### PR TITLE
make sexp-parser use functional-trees of parsley 0.9.2

### DIFF
--- a/paredit.clj/project.clj
+++ b/paredit.clj/project.clj
@@ -6,7 +6,7 @@
             :comments "same as Clojure"}
   :dependencies [[org.clojure/clojure           "1.5.1"]
                  [org.clojure/core.incubator "0.1.1"]
-                 [org.lpetit/net.cgrand.parsley "0.0.12.STABLE001"]
+                 [net.cgrand/parsley "0.9.2"]
                  [org.lpetit/net.cgrand.regex   "0.0.4.STABLE001"]]
   :warn-on-reflection true)
   #_:manifest #_{"Project-awesome-level" "super-great"

--- a/paredit.clj/src/paredit/parser.clj
+++ b/paredit.clj/src/paredit/parser.clj
@@ -5,6 +5,7 @@
   (:use paredit.regex-utils)
 	(:require [clojure.zip :as zip])
   (:require [net.cgrand.parsley :as p])
+  (:require [net.cgrand.parsley.functional-trees :as pf])
   (:require [net.cgrand.parsley.lrplus :as lr+])
   (:require [clojure.string :as str]))
 
@@ -334,8 +335,8 @@
   (p/parser {:root-tag :root
            :main :expr*
            :space (p/unspaced gspaces :*)
-           :make-node make-node
-           :make-leaf make-leaf
+           :make-node pf/fnode
+           :make-leaf pf/fleaf
            :make-unexpected make-unexpected
            }
     :expr- #{


### PR DESCRIPTION
Hi,

I'm not sure about
- use of :make-unexpected (option of sexp) in paredit
- current version of cgrand's parsley... in clojars 0.19.3 it seems to be the for-this-change-required version 0.9.2 already (?)

The idea is  to apply this to clojars 0.19.3, resulting in clojars 0.19.4, so that kovasb Nightcode can depend on it.

But anyway I tested my change Ok.
This change enables using the "offsets" view of newest parsley 0.9.2 with the sexp-parser.
Maybe you already have some public defn-function in paredit for getting all offsets of sexpressions ?
(then I'd like to see an example of it and this change may be unneccessary)

Best,
Joerg
