### PR TITLE
Split sexp papercuts

### DIFF
--- a/paredit.clj/src/paredit/core.clj
+++ b/paredit.clj/src/paredit/core.clj
@@ -453,7 +453,7 @@
     (if-let [rloc (-?> parse-tree (parsed-root-loc true))]
       (let [[l r] (normalized-selection rloc offset length)
             parent (cond
-                     (= :string (loc-tag l)) l ; stay at the same level, and let the code take the correct open/close puncts, e.g. \" \"
+                     (and (= :string (loc-tag l)) (> offset (start-offset l))) l ; stay at the same level, and let the code take the correct open/close puncts, e.g. \" \"
                      :else (if-let [nl (z/up (if (start-punct? l) (parse-node l) (parse-leave l)))] nl (parse-leave l)))
             open-punct (*tag-opening-brackets* (loc-tag parent))
             close-punct ^String (*tag-closing-brackets* (loc-tag parent))]

--- a/paredit.clj/src/paredit/core_commands.clj
+++ b/paredit.clj/src/paredit/core_commands.clj
@@ -717,6 +717,8 @@
                 "(foo|)" "(foo)|()"
                 "({|})" "({}|{})"
                 "(defn hello ;comment\n |[world])" "(defn hello) ;comment\n |([world])"
+                "(|\"\")" "()|(\"\")"
+                "(\"\"|)" "(\"\")|()"
                 }]
      ["M-J"    :paredit-join-sexps
                {"(hello)| (world)" "(hello| world)",


### PR DESCRIPTION
Two fixes:
- when the caret was in front of a string, the string was split instead of the parent form.
- don't mess with spaces and comments when splitting (now splits work even with comments: the closing punct is put before the comment, not after
