### PR TITLE
Embedded nRepl can be choosen through -Dccw.nrepl.port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,38 @@
-/*.zip
-/*.tgz
+*.zip
+*.tgz
 .DS_Store
-*.swp
-/workspace
-.DS_Store
+workspace/
 ccw.repl.cmdhistory.prefs
+.lein-repl-history
 .nrepl
+.project
+*.orig
+
+# https://github.com/github/gitignore/blob/master/Global/Eclipse.gitignore
+*.pydevproject
+.metadata
+.gradle
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.loadpath
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+# CDT-specific
+.cproject
+
+# PDT-specific
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# TeXlipse plugin
+.texlipse

--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -1,12 +1,16 @@
-= Counterclockwise ChangeLog 
+= Counterclockwise ChangeLog
 Laurent Petit <laurent dot petit at gmail dot com>
 :sectanchors:
 :sectlinks:
 :source-highlighter: coderay
 :experimental:
-:toc: 
+:toc:
 :toc-title!:
 :toclevels: 0
+
+== Changes between Counterclockwise 0.32.0 and 0.33.0
+
+- Command line options: `-Dccw.nrepl.port=[1-65535]` allows to select the embedded nrepl port. `ccw.autostartrepl` has been renamed to `ccw.nrepl.autostart` for coherence.
 
 == Changes between Counterclockwise 0.31.2 and 0.32.0
 
@@ -269,7 +273,7 @@ The wizard now accepts `lein new` template arguments. Simply put them after the 
 
 - Adds preferences for REPL history - Contributed by Gunnar Völkel
   - Preference for REPL history size.
-  - Preference for REPL history persistence schedule. 
+  - Preference for REPL history persistence schedule.
 - zombie REPLs (when connection is lost)
   - are automatically disabled (buttons and text grayed, input area non editable)
   - and won't be used for sending code from editors
@@ -287,7 +291,7 @@ The wizard now accepts `lein new` template arguments. Simply put them after the 
 - `REPL View` accepts the Drawbridge protocol, thus allowing `http(s)://<server>:<port>/repl` or `http(s)://<user>:<password>@<server>:<port>/repl` URLs. Fix Issue #501
 - `REPL View` does not open and give proper error message if connection is not possible (e.g. Drawbridge HTTP 401)
 - `Outline View`: There were unexpected exceptions thrown depending on the content of the Editor. These were due to `java.lang.Comparator` contract violations. Fix Issue #639
-- `Editor`: In strict/paredit mode, forward/backward delete do not prevent to remove `#` in front of `()` or `{}` or `""`. Also, fixed a bug where forward delete allowed to remove `(` or `{` or `"` if there was a leading `#`. Fix Issue #523 
+- `Editor`: In strict/paredit mode, forward/backward delete do not prevent to remove `#` in front of `()` or `{}` or `""`. Also, fixed a bug where forward delete allowed to remove `(` or `{` or `"` if there was a leading `#`. Fix Issue #523
   - Also changed a behavior: the cursor is not stuck, either something is deleted, either the cursors moves forward or backward
 
 == Changes between Counterclockwise 0.25.1 and 0.25.2
@@ -472,9 +476,9 @@ Overlapping `:source-paths`, `:resource-paths`,  `:test-paths` and/or `:java-sou
 Counterclockwise resolves the conflict by adding the required exclusions to its source classpath entries.
 
 For instance, if you have declared (explicitly or implicitly) both `resources`  and `resources/public` as resource paths,
-Counterclockwise will create 2 source path entries: 
+Counterclockwise will create 2 source path entries:
 
-- one for `resources/public`, 
+- one for `resources/public`,
 - and one for `resources`, with an exclusion filter for its `public` subfolder
 
 ==== Missing source paths are not reported as errors anymore
@@ -543,9 +547,9 @@ git clone https://gist.github.com/7924786.git ~/.ccw/plugin-additions
 
 === nREPL Version Update
 
-The embedded nREPL client in Counterclockwise, and which is also used to serve as nREPL client when the project does not declare a dependency on nREPL (the majority of the cases) has been upgraded from version `0.2.1` to `0.2.3`. 
+The embedded nREPL client in Counterclockwise, and which is also used to serve as nREPL client when the project does not declare a dependency on nREPL (the majority of the cases) has been upgraded from version `0.2.1` to `0.2.3`.
 
-=== Bug fix 
+=== Bug fix
 
 - Explicitly ask the user for confirmation before launching a second process for the same project
 
@@ -596,7 +600,7 @@ In a nutshell:
   cd ccw
   mvn verify
   cd ccw.product/target/products # the products for Windows / Linux / OS X
-  cd ../../../ccw.updatesite/target/repository # the Software Update Site 
+  cd ../../../ccw.updatesite/target/repository # the Software Update Site
 
 For more information on installing a full-fledged dev environment, see the Wiki Page https://code.google.com/p/counterclockwise/wiki/HowToBuild[How To Build]
 
@@ -717,7 +721,7 @@ will result in:
 +
 [source,clojure]
 ----
-;; from 
+;; from
 (cond test1 expr1
   test2 expr2)
 ;; to
@@ -739,9 +743,9 @@ A common usecase for this is while you're defining a function in the Editor and 
 ** switch to the editor, modify the function, eval via Cmd+Enter ... when the eval succeeds, the last expression entered in the REPl is reevaluated ... repeat ...
 
 
-=== Repl 
+=== Repl
 
-- A bug had slipped in the project classpath management preventing native libraries to load properly, for instance when trying to work with Overtone. Fix Issue #577 
+- A bug had slipped in the project classpath management preventing native libraries to load properly, for instance when trying to work with Overtone. Fix Issue #577
 
 - Reverting the behaviour of the "Evaluate selection" when sending to the REPL : back to using 'in-ns instead of 'ns while transitioning to the selection's namespace
 Fixes Issue #533: ns is sent to REPL instead of in-ns
@@ -765,4 +769,3 @@ Fixes Issue #533: ns is sent to REPL instead of in-ns
 === Better plays as an Eclipse plugin
 
 - CCW plugin does not start unnecessarily when invoking the project's contextual menu
-

--- a/ccw.core/Counterclockwise Plugin.launch
+++ b/ccw.core/Counterclockwise Plugin.launch
@@ -22,7 +22,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -console"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=256m -Xms40m -Xmx1024m -Dorg.eclipse.swt.internal.carbon.smallFonts -Dccw.autostartnrepl"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=256m -Xms40m -Xmx1024m -Dorg.eclipse.swt.internal.carbon.smallFonts -Dccw.nrepl.autostart"/>
 <booleanAttribute key="pde.generated.config" value="false"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.platform.ide"/>

--- a/ccw.core/Counterclockwise Product.launch
+++ b/ccw.core/Counterclockwise Product.launch
@@ -21,7 +21,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -console"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=128m -Xms40m -Xmx512m -Dorg.eclipse.swt.internal.carbon.smallFonts"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=128m -Xms40m -Xmx512m -Dorg.eclipse.swt.internal.carbon.smallFonts -Dccw.nrepl.autostart"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="ccw.branding.ccw"/>
 <stringAttribute key="productFile" value="/ccw.product/ccw.product"/>

--- a/ccw.core/pom.xml
+++ b/ccw.core/pom.xml
@@ -10,14 +10,14 @@
     <version>0.31.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  
+
   <groupId>ccw</groupId>
   <artifactId>ccw.core</artifactId>
   <version>0.31.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>
-    <nrepl.version>0.2.3</nrepl.version>
+    <nrepl.version>0.2.9</nrepl.version>
     <leiningen.version>2.5.0</leiningen.version>
   </properties>
 
@@ -158,6 +158,6 @@
           </executions>
         </plugin>
       </plugins>
-    </build> 
-  
+    </build>
+
 </project>

--- a/ccw.core/src/clj/ccw/core/launch.clj
+++ b/ccw.core/src/clj/ccw/core/launch.clj
@@ -1,7 +1,13 @@
 (ns ccw.core.launch
-  (:require [ccw.eclipse :as e]))
+  (:require [ccw.eclipse :as e]
+            [clojure.tools.nrepl.server :refer [start-server stop-server default-handler]]
+            [clojure.tools.nrepl.ack :refer [handle-ack]]
+            [ccw.eclipse :as e])
+  (:import ccw.CCWPlugin
+           ccw.core.StaticStrings
+           java.lang.System))
 
-(defn default-nrepl-server-listener 
+(defn default-nrepl-server-listener
   "Default listener printing on *out* the nrepl url"
   [{:keys [event-type port project]}]
   (when (= :creation event-type)
@@ -33,3 +39,48 @@
           (format "Error while notifying nrepl listener '%s' of %s event with params %s"
                   n (:type l) (dissoc l :type))
           e)))))
+
+;;;;;;;;;;;
+;; nRepl ;;
+;;;;;;;;;;;
+
+(defonce ^{:author "Andrea Richiardi" :doc "Atom containing the map returned by start-server."}
+  nrepl-server-map-delay (atom nil))
+
+(defn- fill-nrepl-start-delay
+  "Starts an nRepl given the port number."
+  [server-map-delay port]
+  (if server-map-delay
+    server-map-delay
+    (delay (start-server :port port :handler (handle-ack (default-handler))))))
+
+(defn- fill-nrepl-stop-delay
+  "Stops the instance of the running nRepl. Always returns nil."
+  [server-map-delay]
+  (if (and server-map-delay (realized? server-map-delay))
+    (delay (stop-server (force server-map-delay)) nil)
+    (delay nil)))
+
+;; Public API
+(defn ccw-nrepl-port
+  "Return the currently open nRepl's port"
+  []
+  (:port (some-> @nrepl-server-map-delay force)))
+
+(defn ccw-nrepl-start-if-necessary
+  "Starts a nRepl if there is none started, reading the info from
+  eclipse's runtime properties. The result is then stored in the
+  ccw-nrepl-server-map atom. Returns the newly opened socket to it."
+  []
+  (let [nrepl-port (e/property-ccw-nrepl-port)]
+    (when (= 0 nrepl-port)
+      (CCWPlugin/log (str "nRepl port will be automatically selected")))
+    (let [start-server-delay (swap! nrepl-server-map-delay fill-nrepl-start-delay nrepl-port)
+          server-map (force start-server-delay)]
+      (CCWPlugin/log (str "Started ccw nREPL server: nrepl://127.0.0.1:" (:port server-map))))))
+
+(defn ccw-nrepl-stop
+  "Stops the instance of the running nRepl on the underlying atom. Always returns nil."
+  []
+  (CCWPlugin/log (str "Stopping ccw nREPL server..."))
+  (force (swap! nrepl-server-map-delay fill-nrepl-stop-delay)))

--- a/ccw.core/src/java/ccw/CCWPlugin.java
+++ b/ccw.core/src/java/ccw/CCWPlugin.java
@@ -12,10 +12,7 @@
  *******************************************************************************/
 package ccw;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.resources.IProject;
@@ -47,6 +44,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
 import org.osgi.framework.BundleListener;
 
+import ccw.core.StaticStrings;
 import ccw.editors.clojure.IScanContext;
 import ccw.launching.LaunchUtils;
 import ccw.nature.AutomaticNatureAdder;
@@ -54,13 +52,12 @@ import ccw.preferences.PreferenceConstants;
 import ccw.preferences.SyntaxColoringHelper;
 import ccw.repl.REPLView;
 import ccw.repl.SafeConnection;
-import ccw.util.BundleUtils;
+import ccw.util.ClojureInvoker;
 import ccw.util.DisplayUtil;
 import ccw.util.ITracer;
 import ccw.util.NullTracer;
 import ccw.util.Tracer;
 import clojure.lang.Keyword;
-import clojure.lang.Var;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -95,7 +92,6 @@ public class CCWPlugin extends AbstractUIPlugin {
     
     private FontRegistry fontRegistry;
     
-    private ServerSocket ackREPLServer;
     
 	private AutomaticNatureAdder synchronizedNatureAdapter;
 
@@ -109,31 +105,18 @@ public class CCWPlugin extends AbstractUIPlugin {
 			return NullTracer.INSTANCE;
 	}
     
-    public synchronized void startREPLServer() {
-    	if (ackREPLServer == null) {
-	        try {
-	        	// TODO use ClojureOSGi.withBundle instead
-	        	Var startServer = BundleUtils.requireAndGetVar(getBundle().getSymbolicName(), "clojure.tools.nrepl.server/start-server");
-	        	Object defaultHandler = BundleUtils.requireAndGetVar(
-	        	        getBundle().getSymbolicName(),
-	        	        "clojure.tools.nrepl.server/default-handler").invoke();
-	        	Object handler = BundleUtils.requireAndGetVar(
-	        	        getBundle().getSymbolicName(),
-	        	        "clojure.tools.nrepl.ack/handle-ack").invoke(defaultHandler);
-	            ackREPLServer = (ServerSocket)((Map)startServer.invoke(Keyword.intern("handler"), handler)).get(Keyword.intern("server-socket"));
-	            CCWPlugin.log("Started ccw nREPL server: nrepl://127.0.0.1:" + ackREPLServer.getLocalPort());
-	        } catch (Exception e) {
-	            CCWPlugin.logError("Could not start plugin-hosted REPL server", e);
-	            throw new RuntimeException("Could not start plugin-hosted REPL server", e);
-	        }
+    public void startREPLServer() {
+    	try {
+    	    ClojureInvoker.newInvoker(this, "ccw.core.launch")._("ccw-nrepl-start-if-necessary");
+    	} catch (Exception e) {
+    		CCWPlugin.logError("Could not start plugin-hosted REPL server", e);
+    		throw new RuntimeException("Could not start plugin-hosted REPL server", e);
     	}
     }
     
     public int getREPLServerPort() {
-    	if (ackREPLServer == null) {
-    		startREPLServer();
-    	}
-    	return ackREPLServer.getLocalPort();
+    	startREPLServer();
+    	return (Integer) ClojureInvoker.newInvoker(this, "ccw.core.launch")._("ccw-nrepl-port");
     }
 
     public CCWPlugin() {
@@ -144,7 +127,7 @@ public class CCWPlugin extends AbstractUIPlugin {
         super.start(context);
         System.out.println("CCWPlugin.start: ENTER");
         plugin = this;
-        
+
         context.addBundleListener(new BundleListener() {
 			
 			@Override
@@ -172,7 +155,7 @@ public class CCWPlugin extends AbstractUIPlugin {
 										return;
 									Thread.sleep(200);
 								} catch (InterruptedException e) {
-									e.printStackTrace();
+									logError("Error while querying for the active bundle", e);
 								}
 							}
 
@@ -198,30 +181,27 @@ public class CCWPlugin extends AbstractUIPlugin {
 									try {
 										Thread.sleep(200);
 									} catch (InterruptedException e) {
-										e.printStackTrace();
+										logError("Error while trying to Thread.sleep.", e);
 									}
 								}
 							}
 
 							// Here, the workbench is initialized
-					        if (System.getProperty("ccw.autostartnrepl") != null) {
-					        	try {
+							if (System.getProperty(StaticStrings.CCW_PROPERTY_NREPL_AUTOSTART) != null) {
+								try {
 									startREPLServer();
 								} catch (Exception e) {
-									e.printStackTrace();
+									logError("Error while querying for property: " + StaticStrings.CCW_PROPERTY_NREPL_AUTOSTART, e);
 								}
-					        }
-					        
-					        getNatureAdapter().start();
+							}
+
+							getNatureAdapter().start();
 						}
 						
 					}).start();
 				}
 			}
 		});
-        
-
-        
         System.out.println("CCWPlugin.start: EXIT");
     }
     
@@ -310,12 +290,10 @@ public class CCWPlugin extends AbstractUIPlugin {
     }
     
     private void stopREPLServer() {
-    	if (ackREPLServer != null) {
-    		try {
-				ackREPLServer.close();
-			} catch (IOException e) {
-				logError("Error while trying to close ccw internal nrepl server", e);
-			}
+    	try {
+    	    ClojureInvoker.newInvoker(this, "ccw.core.launch")._("ccw-nrepl-stop");
+    	} catch (Exception e) {
+    		logError("Error while trying to close ccw internal nrepl server", e);
     	}
     }
     
@@ -427,7 +405,7 @@ public class CCWPlugin extends AbstractUIPlugin {
                 	return replView;
                 }
             }
-        };
+        }
         
         return null;
     }

--- a/ccw.core/src/java/ccw/core/StaticStrings.java
+++ b/ccw.core/src/java/ccw/core/StaticStrings.java
@@ -1,0 +1,15 @@
+package ccw.core;
+
+/**
+ * Container of static strings, used for various tasks in Counterclockwise.
+ * Examples of string included here can be, command-line properties names, context/injection keys...
+ * @author Andrea Richiardi
+ *
+ */
+public class StaticStrings {
+
+	// Properties
+	public static final String CCW_PROPERTY_NREPL_PORT = "ccw.nrepl.port";
+	public static final String CCW_PROPERTY_NREPL_AUTOSTART = "ccw.nrepl.autostart";
+	
+}


### PR DESCRIPTION
Here it is!

Now ```ccw.nrepl.port=[1-65535]``` allows you to select the embedded nrepl port. I refactored out the code from CCWPlugin and renamed ```ccw.autostartrepl``` -> ```ccw.nrepl.autostart``` for coherence, see commit message as well.

I also added some ```.gitignore``` entries to avoid (my own) mistakes in committing wrong files.