### PR TITLE
Ccw nRepl with full cider support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,39 @@
-/*.zip
-/*.tgz
+*.zip
+*.tgz
 .DS_Store
-*.swp
-/workspace
-.DS_Store
+workspace/
 ccw.repl.cmdhistory.prefs
+.lein-repl-history
 .nrepl
+.project
+*.orig
+
+# https://github.com/github/gitignore/blob/master/Global/Eclipse.gitignore
+*.pydevproject
+.metadata
+.gradle
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+# CDT-specific
+.cproject
+
+# PDT-specific
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# TeXlipse plugin
+.texlipse

--- a/ccw.core/.classpath
+++ b/ccw.core/.classpath
@@ -16,7 +16,6 @@
 	<classpathentry exported="true" kind="lib" path="lib/clj-stacktrace.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/clojure-complete.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/clojure-contrib.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/clojure.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-codec.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-fileupload.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-io.jar"/>
@@ -73,7 +72,7 @@
 	<classpathentry exported="true" kind="lib" path="lib/wagon-http.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/wagon-provider-api.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/cljunit.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/clj"/>
 	<classpathentry kind="src" path="src/java"/>
@@ -82,5 +81,6 @@
 	<classpathentry kind="lib" path="lib/potemkin.jar"/>
 	<classpathentry kind="lib" path="lib/riddley.jar"/>
 	<classpathentry kind="lib" path="lib/tools.reader.jar"/>
+	<classpathentry kind="lib" path="lib/clojure-ccw.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/ccw.core/.classpath
+++ b/ccw.core/.classpath
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry exported="true" kind="lib" path="lib/tools.namespace.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/tools.trace.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/cljs-tooling.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/compliment.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/java.classpath.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/cider-nrepl.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/hamcrest-core.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/pedantic.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/aether-api.jar"/>

--- a/ccw.core/Counterclockwise Plugin.launch
+++ b/ccw.core/Counterclockwise Plugin.launch
@@ -22,7 +22,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -console"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=256m -Xms40m -Xmx1024m -Dorg.eclipse.swt.internal.carbon.smallFonts -Dccw.autostartnrepl"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=256m -Xms40m -Xmx1024m -Dorg.eclipse.swt.internal.carbon.smallFonts -Dccw.nrepl.autostart"/>
 <booleanAttribute key="pde.generated.config" value="false"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.platform.ide"/>

--- a/ccw.core/Counterclockwise Product.launch
+++ b/ccw.core/Counterclockwise Product.launch
@@ -21,7 +21,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -console"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=128m -Xms40m -Xmx512m -Dorg.eclipse.swt.internal.carbon.smallFonts"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=128m -Xms40m -Xmx512m -Dorg.eclipse.swt.internal.carbon.smallFonts -Dccw.nrepl.autostart"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="ccw.branding.ccw"/>
 <stringAttribute key="productFile" value="/ccw.product/ccw.product"/>

--- a/ccw.core/META-INF/MANIFEST.MF
+++ b/ccw.core/META-INF/MANIFEST.MF
@@ -124,7 +124,13 @@ Bundle-ClassPath: .,
  lib/junit.jar,
  lib/cljunit.jar,
  lib/hamcrest-core.jar,
- lib/pedantic.jar
+ lib/pedantic.jar,
+ lib/cider-nrepl.jar,
+ lib/java.classpath.jar,
+ lib/compliment.jar,
+ lib/cljs-tooling.jar,
+ lib/tools.namespace.jar,
+ lib/tools.trace.jar
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Counterclockwise team
 Eclipse-BundleShape: dir

--- a/ccw.core/pom.xml
+++ b/ccw.core/pom.xml
@@ -17,7 +17,7 @@
   <packaging>eclipse-plugin</packaging>
 
   <properties>
-    <nrepl.version>0.2.3</nrepl.version>
+    <nrepl.version>0.2.5</nrepl.version>
     <leiningen.version>2.5.0</leiningen.version>
   </properties>
 

--- a/ccw.core/pom.xml
+++ b/ccw.core/pom.xml
@@ -81,6 +81,16 @@
             <artifactId>ccw.server</artifactId>
             <version>0.1.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.clojure</groupId>
+            <artifactId>java.classpath</artifactId>
+            <version>0.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>cider</groupId>
+            <artifactId>cider-nrepl</artifactId>
+            <version>0.8.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ccw.core/src/clj/ccw/core/launch.clj
+++ b/ccw.core/src/clj/ccw/core/launch.clj
@@ -1,5 +1,10 @@
 (ns ccw.core.launch
-  (:require [ccw.eclipse :as e]))
+  (:require [clojure.tools.nrepl.server :refer [start-server stop-server default-handler]]
+            [clojure.tools.nrepl.ack :refer [handle-ack]]
+            [ccw.eclipse :as e])
+  (:import ccw.CCWPlugin
+           ccw.core.StaticStrings
+           java.lang.System))
 
 (defn default-nrepl-server-listener 
   "Default listener printing on *out* the nrepl url"
@@ -29,7 +34,37 @@
     (try
       (l {:event-type :creation, :port port :project project})
       (catch Exception e
-        (ccw.CCWPlugin/logError
+        (CCWPlugin/logError
           (format "Error while notifying nrepl listener '%s' of %s event with params %s"
                   n (:type l) (dissoc l :type))
           e)))))
+
+;; Embedded nRepl
+(defonce ^{:doc "Atom containing the map returned by start-server."}
+  ccw-nrepl-server-map (atom nil))
+
+(defn ccw-nrepl-start-if-necessary
+  "Starts a nRepl if there is none started, reading the info from
+  eclipse's runtime properties. The result is then stored in the
+  ccw-nrepl-server-map atom."
+  []
+  (when (= nil @ccw-nrepl-server-map)
+    ;; TODO use ClojureOSGi.withBundle instead
+    (let [nrepl-port (e/property-ccw-nrepl-port)]
+      (if (= 0 nrepl-port)
+        (CCWPlugin/log (str "nRepl port will be automatically selected"))
+        (CCWPlugin/log (str "nRepl port will be: " nrepl-port)))
+      (reset! ccw-nrepl-server-map (start-server :port nrepl-port :handler (handle-ack (default-handler))))
+      (CCWPlugin/log (str "Started ccw nREPL server: nrepl://127.0.0.1:" nrepl-port)))))
+
+(defn ccw-nrepl-port
+  []
+  (:port @ccw-nrepl-server-map))
+
+(defn ccw-nrepl-stop
+  "Stops the instance of the running nRepl."
+  []
+  (when-let [server-map @ccw-nrepl-server-map]
+    (stop-server server-map)
+    (reset! ccw-nrepl-server-map nil)
+    (CCWPlugin/log (str "Stopped ccw nREPL server: nrepl://127.0.0.1:" (:port server-map)))))

--- a/ccw.core/src/clj/ccw/core/launch.clj
+++ b/ccw.core/src/clj/ccw/core/launch.clj
@@ -1,7 +1,8 @@
 (ns ccw.core.launch
   (:require [clojure.tools.nrepl.server :refer [start-server stop-server default-handler]]
             [clojure.tools.nrepl.ack :refer [handle-ack]]
-            [ccw.eclipse :as e])
+            [cider.nrepl :refer (cider-nrepl-handler)]
+            [ccw.eclipse :refer [property-ccw-nrepl-port property-ccw-nrepl-cider-enable]])
   (:import ccw.CCWPlugin
            ccw.core.StaticStrings
            java.lang.System))
@@ -50,11 +51,14 @@
   []
   (when (= nil @ccw-nrepl-server-map)
     ;; TODO use ClojureOSGi.withBundle instead
-    (let [nrepl-port (e/property-ccw-nrepl-port)]
+    (let [nrepl-port (property-ccw-nrepl-port)
+          handler (if (property-ccw-nrepl-cider-enable)
+                    (handle-ack cider-nrepl-handler)
+                    (handle-ack (default-handler)))]
       (if (= 0 nrepl-port)
         (CCWPlugin/log (str "nRepl port will be automatically selected"))
         (CCWPlugin/log (str "nRepl port will be: " nrepl-port)))
-      (reset! ccw-nrepl-server-map (start-server :port nrepl-port :handler (handle-ack (default-handler))))
+      (reset! ccw-nrepl-server-map (start-server :port nrepl-port :handler handler))
       (CCWPlugin/log (str "Started ccw nREPL server: nrepl://127.0.0.1:" nrepl-port)))))
 
 (defn ccw-nrepl-port

--- a/ccw.core/src/clj/ccw/eclipse.clj
+++ b/ccw.core/src/clj/ccw/eclipse.clj
@@ -943,7 +943,6 @@
 
 (defn property-ccw-nrepl-port
   "The no-arg function returns the nRepl port number (as Integer) passed
-
   to Eclipse as property (see StaticStrings/CCW_PROPERTY_NREPL_PORT),
   whereas if you pass in a port number, it will be just validated and
   returned (good for testing). In both cases, if the validation fails
@@ -957,6 +956,11 @@
    (if-let [nrepl-port (re-matches port-validating-regex (str port))]
       (Integer/valueOf nrepl-port)
       0)))
+
+(defn property-ccw-nrepl-cider-enable
+  "Returns the value of StaticStrings/CCW_PROPERTY_NREPL_CIDER_ENABLE property."
+  []
+  (System/getProperty StaticStrings/CCW_PROPERTY_NREPL_CIDER_ENABLE))
 
 (deftest property-tests
   (testing "nRepl port validation tests"

--- a/ccw.core/src/clj/ccw/eclipse.clj
+++ b/ccw.core/src/clj/ccw/eclipse.clj
@@ -1,6 +1,7 @@
 (ns ^{:doc "Eclipse interop utilities"}
      ccw.eclipse
-  (:require [clojure.java.io :as io])
+     (:require [clojure.java.io :as io]
+               [clojure.test :refer [deftest testing is]])
   (:use [clojure.core.incubator :only [-?> -?>>]])
   (:import [org.eclipse.core.resources IResource
                                        IProject
@@ -35,7 +36,9 @@
            [java.io File IOException]
            [ccw CCWPlugin]
            [ccw.util PlatformUtil DisplayUtil]
-           [ccw.launching LaunchUtils]))
+           [ccw.launching LaunchUtils]
+           java.lang.System
+           ccw.core.StaticStrings))
 
 (defn adapter
   "Invokes Eclipse Platform machinery to try by all means to adapt object to 
@@ -913,22 +916,52 @@
         (when window-manager (name window-manager))
         type)))
 
-(defn bindings 
-  ([] (bindings (workbench))) 
-  ([service-locator] 
+(defn bindings
+  ([] (bindings (workbench)))
+  ([service-locator]
     (let [binding-service (service service-locator :bindings)]
       (into [] (.getBindings binding-service)))))
 
-(defn save-key-binding! 
+(defn save-key-binding!
   ([desc] (save-key-binding! (workbench) desc))
   ([service-locator desc]
     (let [binding-service (service service-locator :bindings)
           kb (key-binding desc)
           kb-id (-?> kb .getParameterizedCommand .getId)
-          id-binding-map (-?>> (bindings service-locator) 
+          id-binding-map (-?>> (bindings service-locator)
                            (group-by #(-?> % .getParameterizedCommand .getId)))
           id-binding-map (update-in id-binding-map [kb-id] (fnil conj []) kb)]
-      (.savePreferences binding-service 
-        (.getActiveScheme binding-service) 
-        (into-array org.eclipse.jface.bindings.Binding 
+      (.savePreferences binding-service
+        (.getActiveScheme binding-service)
+        (into-array org.eclipse.jface.bindings.Binding
                     (mapcat identity (vals id-binding-map)))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Properties utilities
+
+(def ^:private port-validating-regex #"[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]")
+
+(defn property-ccw-nrepl-port
+  "The no-arg function returns the nRepl port number (as Integer) passed
+
+  to Eclipse as property (see StaticStrings/CCW_PROPERTY_NREPL_PORT),
+  whereas if you pass in a port number, it will be just validated and
+  returned (good for testing). In both cases, if the validation fails
+  the return value is 0."
+  ([]
+    (if-let [nrepl-port (re-matches port-validating-regex
+                                    (System/getProperty StaticStrings/CCW_PROPERTY_NREPL_PORT "0"))]
+      (Integer/valueOf nrepl-port)
+      0))
+  ([port]
+   (if-let [nrepl-port (re-matches port-validating-regex (str port))]
+      (Integer/valueOf nrepl-port)
+      0)))
+
+(deftest property-tests
+  (testing "nRepl port validation tests"
+    (is (= 0 (property-ccw-nrepl-port 0)))
+    (is (= 0 (property-ccw-nrepl-port 65536)))
+    (is (= 4 (property-ccw-nrepl-port 4)))
+    (is (= 4 (property-ccw-nrepl-port "4")))
+    (is (= 65535 (property-ccw-nrepl-port 65535)))))

--- a/ccw.core/src/java/ccw/core/StaticStrings.java
+++ b/ccw.core/src/java/ccw/core/StaticStrings.java
@@ -5,5 +5,6 @@ public class StaticStrings {
 	// Properties
 	public static final String CCW_PROPERTY_NREPL_PORT = "ccw.nrepl.port";
 	public static final String CCW_PROPERTY_NREPL_AUTOSTART = "ccw.nrepl.autostart";
+	public static final String CCW_PROPERTY_NREPL_CIDER_ENABLE = "ccw.nrepl.cider.enable";
 	
 }

--- a/ccw.core/src/java/ccw/core/StaticStrings.java
+++ b/ccw.core/src/java/ccw/core/StaticStrings.java
@@ -1,0 +1,9 @@
+package ccw.core;
+
+public class StaticStrings {
+
+	// Properties
+	public static final String CCW_PROPERTY_NREPL_PORT = "ccw.nrepl.port";
+	public static final String CCW_PROPERTY_NREPL_AUTOSTART = "ccw.nrepl.autostart";
+	
+}


### PR DESCRIPTION
When you connect to nRepl through emacs/cider, a warning is raised:

    ; CIDER 0.8.2 (Java 1.7.0_65, Clojure 1.7.0-01, nREPL 0.2.5) WARNING: The following required nREPL ops are not supported: apropos classpath complete eldoc info inspect-start inspect-refresh inspect-pop inspect-push inspect-reset macroexpand ns-list ns-vars resource stacktrace toggle-trace-var toggle-trace-ns undef Please, install (or update) cider-nrepl 0.8.2 and restart CIDER

To solve this, now the property ```-Dccw.nrepl.cider.enable``` attaches the cider middleware to the embedded nRepl. Very handy if you are used to it.