### PR TITLE
fix(ccw.core): Fix classpath in order to launch from within Eclipse

### DIFF
--- a/ccw.core/.classpath
+++ b/ccw.core/.classpath
@@ -72,7 +72,7 @@
 	<classpathentry exported="true" kind="lib" path="lib/wagon-http.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/wagon-provider-api.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/cljunit.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/clj"/>
 	<classpathentry kind="src" path="src/java"/>


### PR DESCRIPTION
Changes the runtime Execution Environment to JavaSE-1.7 as per MANIFEST.MF and adds clojure_ccw.jar
to classpath so that now CCW can be launched again from within Eclipse's Run/Debug configurations.