### PR TITLE
Ccw nRepl with full cider support (good one)

### DIFF
--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -11,6 +11,7 @@ Laurent Petit <laurent dot petit at gmail dot com>
 == Changes between Counterclockwise 0.32.0 and 0.33.0
 
 - Command line options: `-Dccw.nrepl.port=[1-65535]` allows to select the embedded nrepl port. `ccw.autostartrepl` has been renamed to `ccw.nrepl.autostart` for coherence.
+- Command line options: `-Dccw.nrepl.cider.enable` adds full support for Cider to the embedded nRepl.
 
 == Changes between Counterclockwise 0.31.2 and 0.32.0
 

--- a/ccw.core/.classpath
+++ b/ccw.core/.classpath
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry exported="true" kind="lib" path="lib/tools.namespace.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/tools.trace.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/cljs-tooling.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/compliment.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/java.classpath.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/cider-nrepl.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/hamcrest-core.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/pedantic.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/aether-api.jar"/>

--- a/ccw.core/META-INF/MANIFEST.MF
+++ b/ccw.core/META-INF/MANIFEST.MF
@@ -124,7 +124,13 @@ Bundle-ClassPath: .,
  lib/junit.jar,
  lib/cljunit.jar,
  lib/hamcrest-core.jar,
- lib/pedantic.jar
+ lib/pedantic.jar,
+ lib/cider-nrepl.jar,
+ lib/java.classpath.jar,
+ lib/compliment.jar,
+ lib/cljs-tooling.jar,
+ lib/tools.namespace.jar,
+ lib/tools.trace.jar
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Counterclockwise team
 Eclipse-BundleShape: dir

--- a/ccw.core/pom.xml
+++ b/ccw.core/pom.xml
@@ -81,6 +81,16 @@
             <artifactId>ccw.server</artifactId>
             <version>0.1.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.clojure</groupId>
+            <artifactId>java.classpath</artifactId>
+            <version>0.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>cider</groupId>
+            <artifactId>cider-nrepl</artifactId>
+            <version>0.8.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ccw.core/src/clj/ccw/eclipse.clj
+++ b/ccw.core/src/clj/ccw/eclipse.clj
@@ -943,7 +943,6 @@
 
 (defn property-ccw-nrepl-port
   "The no-arg function returns the nRepl port number (as Integer) passed
-
   to Eclipse as property (see StaticStrings/CCW_PROPERTY_NREPL_PORT),
   whereas if you pass in a port number, it will be just validated and
   returned (good for testing). In both cases, if the validation fails
@@ -957,6 +956,11 @@
    (if-let [nrepl-port (re-matches port-validating-regex (str port))]
       (Integer/valueOf nrepl-port)
       0)))
+
+(defn property-ccw-nrepl-cider-enable
+  "Returns the value of StaticStrings/CCW_PROPERTY_NREPL_CIDER_ENABLE property."
+  []
+  (System/getProperty StaticStrings/CCW_PROPERTY_NREPL_CIDER_ENABLE))
 
 (deftest property-tests
   (testing "nRepl port validation tests"

--- a/ccw.core/src/java/ccw/core/StaticStrings.java
+++ b/ccw.core/src/java/ccw/core/StaticStrings.java
@@ -11,5 +11,6 @@ public class StaticStrings {
 	// Properties
 	public static final String CCW_PROPERTY_NREPL_PORT = "ccw.nrepl.port";
 	public static final String CCW_PROPERTY_NREPL_AUTOSTART = "ccw.nrepl.autostart";
+	public static final String CCW_PROPERTY_NREPL_CIDER_ENABLE = "ccw.nrepl.cider.enable";
 	
 }


### PR DESCRIPTION
When you connect to nRepl through emacs/cider, a warning is raised:

    ; CIDER 0.8.2 (Java 1.7.0_65, Clojure 1.7.0-01, nREPL 0.2.5) WARNING: The following required nREPL ops are not supported: apropos classpath complete eldoc info inspect-start inspect-refresh inspect-pop inspect-push inspect-reset macroexpand ns-list ns-vars resource stacktrace toggle-trace-var toggle-trace-ns undef Please, install (or update) cider-nrepl 0.8.2 and restart CIDER

To solve this, now the property ```-Dccw.nrepl.cider.enable``` attaches the cider middleware to the embedded nRepl. Very handy if you are used to it.