### PR TITLE
Refactor delayed atom paradigm into its own files + tests

### DIFF
--- a/ccw.core.test/src/clj/ccw/util_test.clj
+++ b/ccw.core.test/src/clj/ccw/util_test.clj
@@ -1,0 +1,59 @@
+(ns ccw.util_test
+  (:use clojure.test
+        ccw.util))
+
+(defmacro with-private-fns [[ns fns] & tests]
+  "Refers private fns from ns and runs tests in context."
+  `(let ~(reduce #(conj %1 %2 `(ns-resolve '~ns '~%2)) [] fns)
+     ~@tests))
+
+(defmacro with-atom
+  "Quick and dirty anaphoric macro to build an atom which can be
+  referred in the body with the symbol a."
+  [init & body]
+  `(let [~'a (atom ~init)]
+     ~@body))
+
+(with-private-fns [ccw.util [delayed-atom-fill
+                             delayed-atom-clear]]
+
+  (deftest ccw-core-tests
+    "Tests the ccw.core namespace."
+
+    (testing "Delayed atom - common"
+      (is (not (some? (with-atom nil (deref a)))) "Delayed atom is nil if no op."))
+
+    (testing "Delayed atom swaps - f with params"
+      (defn create-vec
+        [& nums]
+        (apply vector nums))
+
+      (defn keep-vec-index
+        [vec index]
+        (vec (nth vec index)))
+
+      (is (not (realized? (with-atom nil (delayed-atom-swap! a create-vec 4 5 6)))) "Swapping: delay has to be realized explicitely")
+      (is (= [4 5 6] (with-atom nil (force (delayed-atom-swap! a create-vec 4 5 6)))) "Swapping: delay's value is [4 5 6]")
+      (is (some? (with-atom nil (do (delayed-atom-swap! a create-vec 4 5 6) (deref a)))) "Swapping: deref'd delayed atom is not nil.")
+
+      (is (some? (with-atom nil (do (delayed-atom-reset! a keep-vec-index 2) (deref a)))) "Resetting: deref'd delayed atom is not nil (it is still a delay.")
+      (is (= nil (with-atom nil (force (delayed-atom-reset! a keep-vec-index 2)))) "Resetting: delay's value is always nil."))
+
+    (testing "Delayed atom swaps - f with no params"
+      (defn build
+        []
+        {:db-instance "Some instance"})
+
+      (defn unbuild
+        [map]
+        (let [instance (:db-instance map)] (println "Cleared " instance)))
+
+      (is (not (realized? (with-atom nil (delayed-atom-swap! a build)))) "Swapping: delay has to be realized explicitely")
+      (is (= {:db-instance "Some instance"} (with-atom nil (force (delayed-atom-swap! a build)))) "Swapping: delay's value is [4 5 6]")
+      (is (some? (with-atom nil (do (delayed-atom-swap! a build) (deref a)))) "Swapping: deref'd delayed atom is not nil.")
+
+      (is (some? (with-atom nil (do (delayed-atom-reset! a unbuild) (deref a)))) "Resetting: deref'd delayed atom is not nil (it is still a delay.")
+      (is (= nil (with-atom nil (force (delayed-atom-reset! a unbuild)))) "Resetting: delay's value is always nil."))
+
+))
+;; (run-tests)


### PR DESCRIPTION
Hi Laurent! I wanted to refactor your/our idea as I am going to use it in my other PR in order to avoid early calls to ClojureInvoker as you suggested.

The brief summary:
<code>
The patch creates the ccw.core namespace + clj for including utils that we cannot classify in
bundle.clj, eclipse.clj, ...
It also refactors the delayed atom pattern (copyright Laurant Petit) into it with tests.</code>

<code>The pattern is applied to ccw.core.launch were it was originally introduced. This breaks some
private defn name.</code>