### PR TITLE
Finalize tracing, in reference to #743

### DIFF
--- a/ccw.core/META-INF/MANIFEST.MF
+++ b/ccw.core/META-INF/MANIFEST.MF
@@ -44,7 +44,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.ui.widgets,
  org.eclipse.e4.ui.workbench,
  org.eclipse.core.runtime.compatibility,
- org.eclipse.osgi.services
+ org.eclipse.osgi.services,
+ org.eclipse.ui.trace
 Bundle-ClassPath: .,
  src/clj/,
  lib/aether-api-jar/,

--- a/ccw.core/plugin.xml
+++ b/ccw.core/plugin.xml
@@ -3389,4 +3389,14 @@
          </element>
       </processor>
    </extension>
+   <extension
+         point="org.eclipse.ui.trace.traceComponents">
+      <component
+            id="ccw.trace"
+            label="Counterclockwise Core">
+         <bundle
+               name="ccw.*">
+         </bundle>
+      </component>
+   </extension>
 </plugin>


### PR DESCRIPTION
Hello Laurent,
The patch adds CCW entries in Preferences->General->Tracing by implementing the Eclipse tracing
extension point.
It is working fine, even if everything looks async/buffered/unflushed when writing to the the log and you cannot really follow the enable/disable of the tracing options unless you add a nice breakpoint in the DebugOptionsListener...
I put this commit here so that you can see and try by yourself, I am willing to work on the other points of issue #743 as well if you can elaborate on them a little bit further...
Cheers!