### PR TITLE
Tracing

### DIFF
--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -67,3 +67,6 @@ ccw.core/events=false
 
 # Eclipse clojure utilities related traces
 ccw.core/eclipse=false
+
+# Clojure Editor related traces
+ccw.core/editor=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -55,3 +55,6 @@ ccw.core/syntax-color/damager=false
 
 # Leiningen support related traces
 ccw.core/leiningen=false
+
+# Eclipse 4 Model/Workbench related traces
+ccw.core/e4=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -52,3 +52,6 @@ ccw.core/user-plugins=false
 
 # Syntax color - Damager related traces
 ccw.core/syntax-color/damager=false
+
+# Leiningen support related traces
+ccw.core/leiningen=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -73,3 +73,6 @@ ccw.core/editor=false
 
 # Eclipse project management related traces
 ccw.core/project=false
+
+# Repl client related traces
+ccw.core/repl-client=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -58,3 +58,6 @@ ccw.core/leiningen=false
 
 # Eclipse 4 Model/Workbench related traces
 ccw.core/e4=false
+
+# CCW API for User Plugins related traces
+ccw.core/api=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -1,11 +1,48 @@
-ccw.core/log/trace=false
+#
+# These options are used by the Eclipse Tracing framework.
+# They are also read by Counterclockwise Clojure tracing macros to check at
+# compile time that the different tracing features are called with existing
+# tracing options.
+#
+# Every trace option here must have a corresponding trace option in the
+# ccw.TraceOptions java class (for java code consumption).
+#
+
+# Global trace options for enabling/disabling traces
+ccw.core/debug=false
+
+# When true CCWPlugin/log() calls will be traced in trace.log
+# in addition of being logged in .log
 ccw.core/log/info=false
+
+# When true CCWPlugin/logWarning() calls will be traced in trace.log
+# in addition of being logged in .log
 ccw.core/log/warning=false
+
+# When true CCWPlugin/logError() calls will be traced in trace.log
+# in addition of being logged in .log
 ccw.core/log/error=false
+
+# REPLView related traces
 ccw.core/repl=false
+
+# REPLView related traces concerning View focus issues
 ccw.core/repl/focus=false
+
+# Project Builder related traces
 ccw.core/builder=false
+
+# Launch Configurations related traces
 ccw.core/launcher=false
+
+# Autocompletion (content assist) related traces
 ccw.core/autocompletion=false
+
+# Paredit related traces
 ccw.core/paredit=false
+
+# Clojure OSGi integration related traces
 ccw.core/clojure.osgi=false
+
+# Code Outline related traces
+ccw.core/outline=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -49,3 +49,6 @@ ccw.core/outline=false
 
 # User plugins loading related traces
 ccw.core/user-plugins=false
+
+# Syntax color - Damager related traces
+ccw.core/syntax-color/damager=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -13,15 +13,15 @@ ccw.core/debug=false
 
 # When true CCWPlugin/log() calls will be traced in trace.log
 # in addition of being logged in .log
-ccw.core/log/info=false
+ccw.core/log/info=true
 
 # When true CCWPlugin/logWarning() calls will be traced in trace.log
 # in addition of being logged in .log
-ccw.core/log/warning=false
+ccw.core/log/warning=true
 
 # When true CCWPlugin/logError() calls will be traced in trace.log
 # in addition of being logged in .log
-ccw.core/log/error=false
+ccw.core/log/error=true
 
 # REPLView related traces
 ccw.core/repl=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -64,3 +64,6 @@ ccw.core/api=false
 
 # Eclipse Event Broker Clojure wrapper related traces
 ccw.core/events=false
+
+# Eclipse clojure utilities related traces
+ccw.core/eclipse=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -61,3 +61,6 @@ ccw.core/e4=false
 
 # CCW API for User Plugins related traces
 ccw.core/api=false
+
+# Eclipse Event Broker Clojure wrapper related traces
+ccw.core/events=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -46,3 +46,6 @@ ccw.core/clojure.osgi=false
 
 # Code Outline related traces
 ccw.core/outline=false
+
+# User plugins loading related traces
+ccw.core/user-plugins=false

--- a/ccw.core/.options
+++ b/ccw.core/.options
@@ -70,3 +70,6 @@ ccw.core/eclipse=false
 
 # Clojure Editor related traces
 ccw.core/editor=false
+
+# Eclipse project management related traces
+ccw.core/project=false

--- a/ccw.core/src/clj/ccw/api/repl.clj
+++ b/ccw.core/src/clj/ccw/api/repl.clj
@@ -2,6 +2,7 @@
   "Functions related to repl [views] interactions.
    API for User Plugins."
   (:refer-clojure :exclude [send namespace])
+  (:require [ccw.core.trace :as t])
   (:import [ccw.repl REPLView
                      Actions]))
 
@@ -29,7 +30,7 @@
         (boolean add-to-history)
         (boolean print-to-log)
         (boolean repeat-last-eval)))
-    (println "done sending")))
+    (t/trace :api "done sending")))
 
 (defn namespace
   "Get the current namespace for the repl connection"

--- a/ccw.core/src/clj/ccw/clojure_project_nature.clj
+++ b/ccw.core/src/clj/ccw/clojure_project_nature.clj
@@ -11,7 +11,8 @@
 (ns ccw.clojure-project-nature
   (:require [clojure.java.io :as io]
             [ccw.jdt         :as jdt]
-            [ccw.eclipse     :as e])
+            [ccw.eclipse     :as e]
+            [ccw.core.trace  :as t])
   (:import
     [ccw CCWPlugin ClojureCore]
     [java.io IOException File]
@@ -105,7 +106,7 @@
 
 (defn- add-lib-on-classpath!
   [java-project lib-path libSrc-path copy?]
-  (println "about to add lib-path=" lib-path ", libSrc-path=" libSrc-path)
+  (t/format :project "about to add lib-path: %s, libSrc-path: %s" lib-path libSrc-path)
   (io!
     (if (nil? lib-path)
       (throw (CoreException. (Status/CANCEL_STATUS)))
@@ -131,8 +132,8 @@
                (into-array 
                  (conj entries-old 
                    (JavaCore/newLibraryEntry (make-ws-path in-project-lib) (make-ws-path in-project-libSrc) nil)))]
-             (println "java-project:" java-project)
-             (println "entries-new:" (seq entries-new))
+             (t/format :project "java-project: %s" java-project)
+             (t/format :project "entries-new: %s" (seq entries-new))
       	      (doto java-project
       	        (.setRawClasspath entries-new nil)
       	        (.save nil false)

--- a/ccw.core/src/clj/ccw/core/user_plugins.clj
+++ b/ccw.core/src/clj/ccw/core/user_plugins.clj
@@ -2,22 +2,23 @@
   (:require [clojure.java.io :as io]
             [ccw.file :as f]
             [ccw.e4.dsl :as dsl]
-            [ccw.e4.model :as m]))
+            [ccw.e4.model :as m]
+            [ccw.core.trace :as t]))
 
 (defn clean-type-elements!
   "Find all type elements with tag 'ccw', and remove all those that
    dont have 'ccw/load-key' transient key with value load-key."
   [find-type-elements-by-tags application-type-elements app load-key]
-  ;(println "clean-type-elements! load-key=" load-key)
+  (t/format :user-plugins "clean-type-elements! load-key=%s" load-key)
   (let [cmds (find-type-elements-by-tags app ["ccw"])
-        ;_ (println "ccw type elements:" cmds)
+        _ (t/format :user-plugins "ccw type elements: %s" cmds)
         to-remove (remove #(= load-key
                               (get (m/transient-data %) "ccw/load-key")) 
                           cmds)
-        ;_ (println "to-remove:" to-remove)
+        _ (t/format :user-plugins "to-remove: %s" to-remove)
         app-cmds (application-type-elements app)]
     (doseq [c (doall to-remove)] ; prevents ConcurrentModificationExceptions in .remove
-      (println "user-plugins gc, element to remove:" c)
+      (t/format :user-plugins "user-plugins gc, element to remove: %s" c)
       (.remove app-cmds c))))
 
 (defn clean-commands!
@@ -49,7 +50,7 @@
                                 (not= load-key (get (m/transient-data key-binding) "ccw/load-key")))]
                     [key-binding key-bindings])]
     (doseq [[kb kbs] (doall to-remove)] ;; doall prevents ConcurrentModificationExceptions when calling .remove
-      (println "user-plugins gc, key-binding to remove: " kb)
+      (t/format :user-plugins "user-plugins gc, key-binding to remove: %s" kb)
       (.remove kbs kb))))
 
 (defn clean-elements!
@@ -64,7 +65,7 @@
               ["ccw"])
        to-remove (remove #(not= load-key (get (m/transient-data %) "ccw/load-key")) elts)]
    (doseq [e (doall to-remove)] ; prevents ConcurrentModificationExceptions in .remove
-     (println "user-plugins gc, element to remove:" e)
+     (t/format :user-plugins "user-plugins gc, element to remove: %s" e)
      (-> e .getParent .getChildren (.remove e)))))
 
 (defn clean-model!

--- a/ccw.core/src/clj/ccw/e4/dsl.clj
+++ b/ccw.core/src/clj/ccw/e4/dsl.clj
@@ -2,8 +2,9 @@
   "Eclipse 4 DSL namespace.
    You can consider using (:require [ccw.e4.dsl :refer-all])
    since the macros / functions exposed have been carefully chosen."
-  (:require [ccw.e4.model :as m]
-            [ccw.eclipse  :as e])
+  (:require [ccw.e4.model   :as m]
+            [ccw.eclipse    :as e]
+            [ccw.core.trace :as t])
   (:import [ccw.util GenericHandler]))
 
 (def ^:dynamic *load-key* "repl")
@@ -23,7 +24,7 @@
                    (update-in [:tags]
                               (fnil conj #{})
                               "ccw"))]
-       ;(println "spec#:" spec#)
+       (t/format :e4 "spec#: %s" spec#)
        (m/merge-command! @m/app spec#))))
 
 (defmacro defcommand
@@ -104,7 +105,7 @@
                      (update-in [:tags]
                        (fnil conj #{})
                        "ccw"))]
-         ;(println "spec#:" spec#)
+         (t/format :e4 "spec#: %s" spec#)
          (m/merge-handler! @m/app spec#)))))
 
 ;; TODO support options !!!
@@ -153,5 +154,5 @@
                    (update-in [:tags]
                               (fnil conj #{})
                               "ccw"))]
-     ;(println "spec#:" spec#)
+     (t/format :e4 "spec#: %s" spec#)
      (m/merge-key-binding! @m/app spec#)))

--- a/ccw.core/src/clj/ccw/eclipse.clj
+++ b/ccw.core/src/clj/ccw/eclipse.clj
@@ -1,7 +1,8 @@
 (ns ^{:doc "Eclipse interop utilities"}
      ccw.eclipse
      (:require [clojure.java.io :as io]
-               [clojure.test :refer [deftest testing is]])
+               [clojure.test :refer [deftest testing is]]
+               [ccw.core.trace :as t])
   (:use [clojure.core.incubator :only [-?> -?>>]])
   (:import [org.eclipse.core.resources IResource
                                        IProject
@@ -441,7 +442,7 @@
 
 (defn remove-desc-natures! [^IProjectDescription desc & nature-ids]
   (let [natures (.getNatureIds desc)]
-    (println "(some (set natures) nature-ids)" (some (set natures) nature-ids))
+    (t/format :eclipse "(some (set natures) nature-ids): %s" (some (set natures) nature-ids))
     (if (some (set natures) nature-ids)
       (let [new-natures (remove (set nature-ids) natures)]
         (desc-natures! desc new-natures))
@@ -470,9 +471,9 @@
 (defn context-map->project
   "Extract (if possible) a project from a context-map"
   [{:keys [active-selection active-part active-editor]}]
-  (println "active-selection:" active-selection)
-  (println "active-part:" active-part)
-  (println "active-editor:" active-editor)
+  (t/format :eclipse "active-selection: %s" active-selection)
+  (t/format :eclipse "active-part: %s" active-part)
+  (t/format :eclipse "active-editor: %s" active-editor)
   (cond
     (project active-part) (project active-part)
     (and
@@ -748,10 +749,10 @@
         id (name (:command-id hspec))
         prev-handler-activation (@global-handlers id)]
     (when prev-handler-activation
-      (println "deactivating previous handler")
+      (t/trace :eclipse "deactivating previous handler")
       (.deactivateHandler hdl-service prev-handler-activation))
     (let [handler-activation (define-handler!* hspec)]
-      (println "registering new handler")
+      (t/trace :eclipse "registering new handler")
       (swap! global-handlers assoc id handler-activation))))
 
 (def default-category

--- a/ccw.core/src/clj/ccw/editors/clojure/PareditAutoAdjustWhitespaceStrategyImpl.clj
+++ b/ccw.core/src/clj/ccw/editors/clojure/PareditAutoAdjustWhitespaceStrategyImpl.clj
@@ -31,7 +31,6 @@
                                {:offset (.offset command)
                                 :length (.length command) 
                                 :text   (.text command)})]
-;        (println "{[modif] :modifs offset :offset}:" {[modif] :modifs offset :offset})
         (set! (.offset command) (-> modif :offset))
         (set! (.length command) (-> modif :length))
         (set! (.text command) (-> modif :text))

--- a/ccw.core/src/clj/ccw/editors/clojure/clojure_proposal_processor.clj
+++ b/ccw.core/src/clj/ccw/editors/clojure/clojure_proposal_processor.clj
@@ -444,6 +444,5 @@
             (reset! context-info new-context-info))
           (isContextInformationValid 
             [this offset]
-            ;(println "isValid called for offset:" offset)
             (let [{:keys [start stop]} (meta @context-info)]
               (<= start offset stop))))))))

--- a/ccw.core/src/clj/ccw/editors/clojure/editor_common.clj
+++ b/ccw.core/src/clj/ccw/editors/clojure/editor_common.clj
@@ -8,7 +8,7 @@
             [clojure.zip :as z]
             [ccw.core.doc-utils :as doc]
             [ccw.debug.serverrepl :as serverrepl]
-            [ccw.core.trace :as trace]
+            [ccw.core.trace :as t]
             [ccw.editors.clojure.editor-support :as editor])
   (:use [clojure.core.incubator :only [-?>]])
   (:import [org.eclipse.jface.viewers StyledString
@@ -87,7 +87,7 @@
       (try
         (apply send-message* safe-connection message rest)
         (catch java.util.concurrent.TimeoutException e
-          (println " timeout !")
+          (t/trace :editor "timeout sending message: %s" message)
           (swap! timed-out-safe-connections update-in [safe-connection] (fnil inc 0)))))))
 
 (defn parse-symbol? 

--- a/ccw.core/src/clj/ccw/editors/clojure/nrepl_hyperlink_detector.clj
+++ b/ccw.core/src/clj/ccw/editors/clojure/nrepl_hyperlink_detector.clj
@@ -2,7 +2,8 @@
   (:require [clojure.zip :as z]
             [paredit.loc-utils :as lu]
             [ccw.editors.clojure.editor-support :as editor]
-            [ccw.editors.clojure.hyperlink :as hyperlink])
+            [ccw.editors.clojure.hyperlink :as hyperlink]
+            [ccw.core.trace :as t])
   (:use [clojure.core.incubator :only [-?>]])
   (:import 
     [org.eclipse.jface.text BadLocationException
@@ -40,13 +41,12 @@
 
 (defn detect-hyperlinks
   [offset ^IDocument document]
-  ;(println "nrepl hyperlink")
   (let [region (.getLineInformationOfOffset document offset)
         [line-offset line-length] [(.getOffset region) (.getLength region)]
         line (.get document line-offset line-length)]
-    ;(println "line:" line)
+    (t/format :editor "line: %s" line)
     (when-let [[offset length [_ host port]] (find-match-for-offset pattern line (- offset line-offset))]
-      ;(println "nrepl hyperlink:" :offset (+ line-offset offset) :length length)
+      (t/format :editor "nrepl hyperlink: [:offset :length]: [%s %s]" (+ line-offset offset) length)
       [{:offset (+ line-offset offset) :length length
         :open #(ccw.repl.REPLView/connect (format "nrepl://%s:%s" host port) true)}])))
 

--- a/ccw.core/src/clj/ccw/editors/outline.clj
+++ b/ccw.core/src/clj/ccw/editors/outline.clj
@@ -31,8 +31,7 @@
     (catch LispReader$ReaderException e
       ; once a syntax error occurs (often because of a namespaced keyword)
       ; there's little chance that the rest of the data will be worthwhile...
-      (t/trace :log/trace "Failed to read outline 'til the end" e)
-      ;(CCWPlugin/logWarning "Failed to read outline 'til the end", e)
+      (t/trace :outline "Failed to read outline 'til the end" e)
       eof)))
 
 (defn read-forms [s]

--- a/ccw.core/src/clj/ccw/events.clj
+++ b/ccw.core/src/clj/ccw/events.clj
@@ -1,22 +1,13 @@
-(ns ccw.events)
+(ns ccw.events
+  (:require [ccw.e4.model]
+            [ccw.core.trace :as t]))
 
-(try
-  (require '[ccw.e4.model])
-  (catch Exception e
-    (println "ccw.e4.model could not be loaded.")))
-
-;; remove this once CCW has definitely dropped Eclipse 3.x support
 (def DATA
   "IEventBroker/DATA"
   "org.eclipse.e4.data")
 
-(def event-broker
-  (delay
-    (try 
-      (ccw.e4.model/context-key @ccw.e4.model/app :event-broker)
-      (catch Exception e
-        (println "Event Broker cannot be loaded. Please upgrade to Eclipse 4")
-        nil))))
+(defn event-broker []
+  (ccw.e4.model/context-key @ccw.e4.model/app :event-broker))
 
 (defn as-topic [t]
   (cond
@@ -27,40 +18,34 @@
   (-> t (.replaceAll "\\/" ".") keyword))
 
 (defn send-event [topic data]
-  (when-let [event-broker @event-broker]
-    (println "will send" (as-topic topic) ", data:" data)
-    ;; we force the data type to smth other than a Map so
-    ;; we get consistent behavior in the handler
-    (.send event-broker (as-topic topic) [data])))
+  (t/format :events "will send %s, data: %s" (as-topic topic) data)
+  ;; we force the data type to smth other than a Map so
+  ;; we get consistent behavior in the handler
+  (.send (event-broker) (as-topic topic) [data]))
 
 (defn post-event [topic data]
-  (println "will post" (as-topic topic) ", data:" data)
-  (when-let [event-broker @event-broker]
-    ;; we force the data type to smth other than a Map so
-    ;; we get consistent behavior in the handler
-    (.post event-broker (as-topic topic) [data])))
+  (t/format :events "will post %s, data: %s" (as-topic topic) data)
+  ;; we force the data type to smth other than a Map so
+  ;; we get consistent behavior in the handler
+  (.post (event-broker) (as-topic topic) [data]))
 
 (defn subscribe
   ([topic event-handler-var] (subscribe topic false event-handler-var))
   ([topic require-ui? event-handler-var]
-    (println "subscribing to topic" (as-topic topic))
-    (when-let [event-broker @event-broker]
-      (let [event-handler
-            (reify org.osgi.service.event.EventHandler
-              (handleEvent [this event]
-                (event-handler-var
-                  (topic-as-keyword (.getTopic event))
-                  ;; call to (get 0) to extract the data from the
-                  ;; vector
-                  (first (.getProperty event DATA)))))]
-        (when (.subscribe event-broker
-                (as-topic topic)
-                nil
-                event-handler
-                (boolean require-ui?))
-          event-handler)))))
+    (t/format :events "subscribing to topic %s" (as-topic topic))
+    (let [event-handler
+          (reify org.osgi.service.event.EventHandler
+            (handleEvent [this event]
+              (event-handler-var
+                (topic-as-keyword (.getTopic event))
+                ;; call to (get 0) to extract the data from the vector
+                (first (.getProperty event DATA)))))]
+      (when (.subscribe (event-broker)
+              (as-topic topic)
+              nil
+              event-handler
+              (boolean require-ui?))
+        event-handler))))
 
 (defn unsubscribe [event-handler]
-  (when-let [event-broker @event-broker]
-    (.unsubscribe event-broker
-      event-handler)))
+  (.unsubscribe (event-broker) event-handler))

--- a/ccw.core/src/clj/ccw/jdt.clj
+++ b/ccw.core/src/clj/ccw/jdt.clj
@@ -9,8 +9,6 @@
            [org.eclipse.core.resources IResource]
            [org.eclipse.core.runtime IPath]))
 
-(println "ccw.jdt load starts")
-
 ;; We do not directly reference org.eclipse.jdt.ui/PreferenceConstants
 ;; because depending on when the class is imported, its initialization may occur
 ;; too early, which can cause subtle issues such as SWT invalid thread access errors
@@ -145,5 +143,3 @@
         path
         (e/path (default-output-path java-project)))
       progress-monitor)))
-
-(println "ccw.jdt namespace loaded")

--- a/ccw.core/src/clj/ccw/leiningen/classpath_container.clj
+++ b/ccw.core/src/clj/ccw/leiningen/classpath_container.clj
@@ -10,7 +10,8 @@
             [ccw.eclipse :as e]
             [ccw.jdt :as jdt]
             [clojure.java.io :as io]
-            [ccw.leiningen.util :as u])
+            [ccw.leiningen.util :as u]
+            [ccw.core.trace :as t])
   (:import [org.eclipse.core.runtime CoreException
                                      IPath
                                      IProgressMonitor
@@ -32,7 +33,7 @@
            [java.io File
                     FilenameFilter]))
 
-(println "ccw.leiningen.classpath-container load starts")
+(t/trace :leiningen "ccw.leiningen.classpath-container load starts")
 
 (def CONTAINER-PATH (Path. "ccw.LEININGEN_CONTAINER"))
 
@@ -170,7 +171,7 @@
   (let [dependencies (resolve-dependencies project-name :dependencies lein-project)
         default-native-platform-path (u/lein-native-platform-path lein-project)
         srcmap (get-source-map lein-project)]
-    ;(println "default-native-platform-path:" default-native-platform-path)
+    (t/format :leiningen "default-native-platform-path: %s" default-native-platform-path)
     (->> dependencies
       (filter #(re-find #"\.(jar|zip)$" (.getName ^File %)))
       (sort-by #(.getName ^File %))
@@ -258,8 +259,7 @@
 
 (defn- report-container-error [?project message ^Throwable e]
   (add-container-marker (e/resource ?project) message)
-  (println message)
-  (.printStackTrace e))
+  (t/trace :leiningen message e))
 
 (defn- unresolved-artifacts [artifact-results]
   (remove #(.isResolved %) artifact-results))
@@ -364,7 +364,7 @@
    do not touch the current lein container."
   [java-project] ;; TODO checks
   (try
-    (let [lein-project (u/lein-project java-project :enhance-fn #(do (println %) (dissoc % :hooks)))
+    (let [lein-project (u/lein-project java-project :enhance-fn #(do (t/trace :leiningen %) (dissoc % :hooks)))
           deps (get-project-dependencies (.getName (e/project java-project)) lein-project)]
       ;; Here, get-project-dependencies has succeeded or thrown an error
       ;; it can take a long time, so we do not put it inside the workspace job
@@ -432,4 +432,4 @@
     (getDescription [container-path, java-project]
       CONTAINER-DESCRIPTION)))
 
-(println "classpath-container namespace loaded")
+(t/trace :leiningen "classpath-container namespace loaded")

--- a/ccw.core/src/clj/ccw/leiningen/classpath_container.clj
+++ b/ccw.core/src/clj/ccw/leiningen/classpath_container.clj
@@ -1,5 +1,3 @@
-(println "ccw.leiningen.classpath-container before ns decl")
-
 (ns ccw.leiningen.classpath-container
   (:use [clojure.core.incubator :only [-?> -?>>]])
   (:require [leiningen.core.project :as p]

--- a/ccw.core/src/clj/ccw/leiningen/classpath_container_ui.clj
+++ b/ccw.core/src/clj/ccw/leiningen/classpath_container_ui.clj
@@ -7,8 +7,6 @@
            [org.eclipse.swt.widgets Composite]
            [ccw.leiningen Messages]))
 
-(println "ccw.leiningen.classpath-container-ui load starts")
-
 (defn page-factory 
   "Creates a IClasspathContainerPage instance for Leiningen Managed Dependencies"
   [_]
@@ -29,4 +27,3 @@
     (.setDescription (Messages/PageDesc))
     (.setPageComplete true)))
 
-(println "classpath-container-ui namespace loaded")

--- a/ccw.core/src/clj/ccw/leiningen/handlers.clj
+++ b/ccw.core/src/clj/ccw/leiningen/handlers.clj
@@ -5,7 +5,8 @@
             [ccw.leiningen.generic-launch      :as glaunch]
             [clojure.string                    :as str]
             [ccw.eclipse                       :as e]
-            [clojure.java.io                   :as io])
+            [clojure.java.io                   :as io]
+            [ccw.core.trace                    :as t])
   (:import [org.eclipse.core.runtime       CoreException
                                            IPath
                                            Path
@@ -32,7 +33,7 @@
            [java.io                        File
                                            FilenameFilter]))
 
-(println "ccw.leiningen.handlers load starts")
+(t/trace :leiningen "ccw.leiningen.handlers load starts")
 
 (defn update-dependencies
   "Pre-requisites:
@@ -167,4 +168,4 @@
   (when-let [java-project (e/event->java-project event)]
     (upgrade-project-build-path java-project false)))
 
-(println "ccw.leiningen.handlers namespace loaded")
+(t/trace :leiningen "ccw.leiningen.handlers namespace loaded")

--- a/ccw.core/src/clj/ccw/leiningen/nature.clj
+++ b/ccw.core/src/clj/ccw/leiningen/nature.clj
@@ -5,7 +5,8 @@
             [ccw.jdt                           :as jdt]
             [clojure.java.io                   :as io]
             [ccw.leiningen.util                :as u]
-            [ccw.bundle                        :as b])
+            [ccw.bundle                        :as b]
+            [ccw.core.trace                    :as t])
   (:import 
     [org.eclipse.core.resources     IProjectNature
                                     IWorkspaceRoot]
@@ -34,7 +35,7 @@
     [java.io                        File
                                     FilenameFilter]))
 
-(println "ccw.leiningen.nature load starts")
+(t/trace :leiningen "ccw.leiningen.nature load starts")
 
 (def NATURE-ID "ccw.leiningen.nature")
 
@@ -91,7 +92,7 @@
      - or if no JVM version specified in Lein, pick the default one
    - Install a Leiningen Classpath Container" 
   [java-proj]
-  (let [lein-proj        (u/lein-project (e/project java-proj) :enhance-fn #(do (println %) (dissoc % :hooks)))
+  (let [lein-proj        (u/lein-project (e/project java-proj) :enhance-fn #(do (t/trace :leiningen %) (dissoc % :hooks)))
         jvm-entry        (jvm-entry-or-default java-proj)
         source-folders   (lein-source-folders lein-proj)
         source-entries   (map (fn [path] 
@@ -189,4 +190,4 @@
           (.setRule (e/workspace-root))
           (.schedule))))))
 
-(println "ccw.leiningen.nature namespace loaded")
+(t/trace :leiningen "ccw.leiningen.nature namespace loaded")

--- a/ccw.core/src/clj/ccw/leiningen/util.clj
+++ b/ccw.core/src/clj/ccw/leiningen/util.clj
@@ -5,20 +5,21 @@
             [leiningen.core.utils :as utils]
             [leiningen.core.classpath :as classpath]
             [classlojure.core :as c]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [ccw.core.trace :as t])
   (:import [org.eclipse.core.resources IProject]
            [java.io File]
            [org.eclipse.core.runtime Platform
                                      FileLocator]))
 
-(println "ccw.leiningen.util load starts")
+(t/trace :leiningen "ccw.leiningen.util load starts")
 
 ;; TODO port back to ccw.core for the nature (place in ccw.util)
 (defn bundle-file 
   "given bundle-name (a String), return the java.io.File corresponding to the
    currently loaded instance of this bundle"
   [bundle-name]
-  (println "bundle-file:" bundle-name)
+  (t/format :leiningen "bundle-file: %s" bundle-name)
   (-> bundle-name Platform/getBundle FileLocator/getBundleFile))
 
 (defn bundle-dir 
@@ -181,4 +182,4 @@
                 "--"
                 '~args)))))
 
-(println "util namespace loaded")
+(t/trace :leiningen "util namespace loaded")

--- a/ccw.core/src/clj/ccw/leiningen/wizard.clj
+++ b/ccw.core/src/clj/ccw/leiningen/wizard.clj
@@ -3,7 +3,8 @@
             [ccw.eclipse :as e]
             [ccw.leiningen.nature :as n]
             [ccw.leiningen.handlers :as handlers]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [ccw.core.trace :as t])
   (:import  [org.eclipse.core.resources IProject IResource]
             [org.eclipse.jdt.core JavaCore]))
 
@@ -23,9 +24,8 @@
 
 (defn perform-finish [lein-project-name ^IProject project template-name template-args]
   (let [project-file (-> project .getLocation .toFile)]
-    (println "lein-project-name:" lein-project-name
-             \newline
-             "project-file:" project-file)
+    (t/format :leiningen
+      "lein-project-name: %s\nproject-file: %s" lein-project-name project-file)
     (u/lein-new (.getAbsolutePath project-file) template-name lein-project-name template-args)
     (.refreshLocal project (IResource/DEPTH_INFINITE) nil)
     (handlers/add-natures

--- a/ccw.core/src/java/ccw/CCWDropAdapterEarlyStartup.java
+++ b/ccw.core/src/java/ccw/CCWDropAdapterEarlyStartup.java
@@ -78,7 +78,6 @@ public class CCWDropAdapterEarlyStartup implements IStartup {
 
 	@Override
 	public void earlyStartup() {
-		System.out.println("CCW EARLY STARTUP");
 		UIJob registerJob = new UIJob(Display.getDefault(),
 				"CCWDropAdapterEarlyStartup") {
 			{
@@ -211,26 +210,10 @@ public class CCWDropAdapterEarlyStartup implements IStartup {
 			for (int op : PREFERRED_DROP_OPERATIONS) {
 				if ((allowedOperations & op) != 0) {
 					e.detail = op;
-					traceDropOperation(e.detail);
 					return;
 				}
 			}
 			e.detail = allowedOperations;
-			traceDropOperation(e.detail);
-		}
-		private void traceDropOperation(int op) {
-/*
-			if ((op & DND.DROP_COPY) != 0)
-				System.out.println("DROP_COPY");
-			if (op  == DND.DROP_DEFAULT)
-				System.out.println("DROP_DEFAULT");
-			if ((op & DND.DROP_LINK) != 0)
-				System.out.println("DROP_LINK");
-			if ((op & DND.DROP_MOVE) != 0)
-				System.out.println("DROP_MOVE");
-			if (op == DND.DROP_NONE)
-				System.out.println("DROP_NONE");
-*/
 		}
 
 		private void updateDragDetails(DropTargetEvent e) {
@@ -245,7 +228,6 @@ public class CCWDropAdapterEarlyStartup implements IStartup {
 
 		@Override
 		public void drop(DropTargetEvent event) {
-			System.out.println("drop " + event.widget.hashCode());
 			if (urlTransfer.isSupportedType(event.currentDataType)) {
 				// TODO url fetching on windows more complex than that => check how Eclise market place does it
 				final String url = getUrlFromEvent(event);

--- a/ccw.core/src/java/ccw/CCWPlugin.java
+++ b/ccw.core/src/java/ccw/CCWPlugin.java
@@ -232,8 +232,11 @@ public class CCWPlugin extends AbstractUIPlugin {
     @Override
 	public void start(BundleContext context) throws Exception {
         super.start(context);
-        System.out.println("CCWPlugin.start: ENTER");
         plugin = this;
+        log("CCWPlugin.start(): ENTER");
+
+		tracer = new Tracer(context);
+
         logDependenciesInformation(context);
 
         context.addBundleListener(new BundleListener() {
@@ -242,8 +245,6 @@ public class CCWPlugin extends AbstractUIPlugin {
 			public void bundleChanged(BundleEvent evt) {
 				if (evt.getBundle() == CCWPlugin.this.getBundle()
 					&&	evt.getType() == BundleEvent.STARTED) {
-
-					tracer = new Tracer(evt.getBundle().getBundleContext(), TraceOptions.getTraceOptions());
 
 					// We immediately give control back to the OSGi framework application
 					// by starting the code in a new thread
@@ -310,7 +311,7 @@ public class CCWPlugin extends AbstractUIPlugin {
 				}
 			}
 		});
-        System.out.println("CCWPlugin.start: EXIT");
+        log("CCWPlugin.start(): EXIT");
     }
     
     private synchronized AutomaticNatureAdder getNatureAdapter() {

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -1,44 +1,60 @@
 package ccw;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
+ * These constants are used by Java code invoking Eclipse Tracing features.
+ * <p>
+ * Eclipse tracing features are exposed via <code>CCWPlugin.getTracer()</code>
+ * <p>
+ * Every trace option here must correspond to a trace option in the
+ * .options file of bundle ccw.core.
+ *
  * @author laurentpetit
  */
 public class TraceOptions {
 
-	public static final String LOG_TRACE = "log/trace";
+	/** Global trace options for enabling/disabling traces */
+	public static final String DEBUG = "debug";
+
+	/**
+	 * When true CCWPlugin/log() calls will be traced in trace.log
+	 * in addition of being logged in .log
+	 */
 	public static final String LOG_INFO = "log/info";
+
+	/**
+	 * When true CCWPlugin/logWarning() calls will be traced in trace.log
+	 * in addition of being logged in .log
+	 */
 	public static final String LOG_WARNING = "log/warning";
+
+	/**
+	 * When true CCWPlugin/logError() calls will be traced in trace.log
+	 * in addition of being logged in .log
+	 */
 	public static final String LOG_ERROR = "log/error";
 
+	/** REPLView related traces */
 	public static final String REPL = "repl";
+
+	/** REPLView related traces concerning View focus issues */
 	public static final String REPL_FOCUS = "repl/focus";
+
+	/** Project Builder related traces */
 	public static final String BUILDER = "builder";
+
+	/** Launch Configurations related traces */
 	public static final String LAUNCHER = "launcher";
+
+	/** Autocompletion (content assist) related traces */
 	public static final String AUTOCOMPLETION = "autocompletion";
+
+	/** Paredit related traces */
 	public static final String PAREDIT = "paredit";
+
+	/** Clojure OSGi integration related traces */
 	public static final String CLOJURE_OSGI = "clojure.osgi";
 
-	@SuppressWarnings("serial")
-	public static final Map<String, Boolean> getTraceOptions() {
-		return new HashMap<String, Boolean>() {
-			{
-				put(LOG_TRACE, false);
-				put(LOG_INFO, false);
-				put(LOG_WARNING, false);
-				put(LOG_ERROR, false);
-
-				put(REPL, false);
-				put(REPL_FOCUS, false);
-				put(BUILDER, false);
-				put(LAUNCHER, false);
-				put(AUTOCOMPLETION, false);
-				put(PAREDIT, false);
-				put(CLOJURE_OSGI, false);
-			}
-		};
-	}
+	/** Code Outline related traces */
+	public static final String OUTLINE = "outline";
 
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -75,4 +75,7 @@ public class TraceOptions {
 	/** Eclipse Event Broker Clojure wrapper related traces */
 	public static final String EVENTS = "/events";
 
+	/** Eclipse clojure utilities related traces */
+	public static final String ECLIPSE = "/eclipse";
+
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -62,4 +62,7 @@ public class TraceOptions {
 
 	/** Syntax color - Damager related traces */
    public static final String SYNTAX_COLOR__DAMAGER = "/syntax-color/damager";
+
+   /** Leiningen support related traces */
+   public static final String LEININGEN = "/leiningen";
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -84,4 +84,7 @@ public class TraceOptions {
 	/** Eclipse project management related traces */
 	public static final String PROJECT = "/project";
 
+	/** Repl client related traces */
+	public static final String REPL_CLIENT = "/repl-client";
+
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -57,4 +57,7 @@ public class TraceOptions {
 	/** Code Outline related traces */
 	public static final String OUTLINE = "/outline";
 
+	/** User plugins loading related traces */
+	public static final String USER_PLUGINS = "/user-plugins";
+
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -13,48 +13,48 @@ package ccw;
 public class TraceOptions {
 
 	/** Global trace options for enabling/disabling traces */
-	public static final String DEBUG = "debug";
+	public static final String DEBUG = "/debug";
 
 	/**
 	 * When true CCWPlugin/log() calls will be traced in trace.log
 	 * in addition of being logged in .log
 	 */
-	public static final String LOG_INFO = "log/info";
+	public static final String LOG_INFO = "/log/info";
 
 	/**
 	 * When true CCWPlugin/logWarning() calls will be traced in trace.log
 	 * in addition of being logged in .log
 	 */
-	public static final String LOG_WARNING = "log/warning";
+	public static final String LOG_WARNING = "/log/warning";
 
 	/**
 	 * When true CCWPlugin/logError() calls will be traced in trace.log
 	 * in addition of being logged in .log
 	 */
-	public static final String LOG_ERROR = "log/error";
+	public static final String LOG_ERROR = "/log/error";
 
 	/** REPLView related traces */
-	public static final String REPL = "repl";
+	public static final String REPL = "/repl";
 
 	/** REPLView related traces concerning View focus issues */
-	public static final String REPL_FOCUS = "repl/focus";
+	public static final String REPL_FOCUS = "/repl/focus";
 
 	/** Project Builder related traces */
-	public static final String BUILDER = "builder";
+	public static final String BUILDER = "/builder";
 
 	/** Launch Configurations related traces */
-	public static final String LAUNCHER = "launcher";
+	public static final String LAUNCHER = "/launcher";
 
 	/** Autocompletion (content assist) related traces */
-	public static final String AUTOCOMPLETION = "autocompletion";
+	public static final String AUTOCOMPLETION = "/autocompletion";
 
 	/** Paredit related traces */
-	public static final String PAREDIT = "paredit";
+	public static final String PAREDIT = "/paredit";
 
 	/** Clojure OSGi integration related traces */
-	public static final String CLOJURE_OSGI = "clojure.osgi";
+	public static final String CLOJURE_OSGI = "/clojure.osgi";
 
 	/** Code Outline related traces */
-	public static final String OUTLINE = "outline";
+	public static final String OUTLINE = "/outline";
 
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -69,4 +69,7 @@ public class TraceOptions {
 	/** Eclipse 4 Model/Workbench related traces */
 	public static final String E4 = "/e4";
 
+	/** CCW API for User Plugins related traces */
+	public static final String API = "/api";
+
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -60,4 +60,6 @@ public class TraceOptions {
 	/** User plugins loading related traces */
 	public static final String USER_PLUGINS = "/user-plugins";
 
+	/** Syntax color - Damager related traces */
+   public static final String SYNTAX_COLOR__DAMAGER = "/syntax-color/damager";
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -61,8 +61,12 @@ public class TraceOptions {
 	public static final String USER_PLUGINS = "/user-plugins";
 
 	/** Syntax color - Damager related traces */
-   public static final String SYNTAX_COLOR__DAMAGER = "/syntax-color/damager";
+	public static final String SYNTAX_COLOR__DAMAGER = "/syntax-color/damager";
 
-   /** Leiningen support related traces */
-   public static final String LEININGEN = "/leiningen";
+	/** Leiningen support related traces */
+	public static final String LEININGEN = "/leiningen";
+
+	/** Eclipse 4 Model/Workbench related traces */
+	public static final String E4 = "/e4";
+
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -81,4 +81,7 @@ public class TraceOptions {
 	/** Clojure Editor related traces */
 	public static final String EDITOR = "/editor";
 
+	/** Eclipse project management related traces */
+	public static final String PROJECT = "/project";
+
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -72,4 +72,7 @@ public class TraceOptions {
 	/** CCW API for User Plugins related traces */
 	public static final String API = "/api";
 
+	/** Eclipse Event Broker Clojure wrapper related traces */
+	public static final String EVENTS = "/events";
+
 }

--- a/ccw.core/src/java/ccw/TraceOptions.java
+++ b/ccw.core/src/java/ccw/TraceOptions.java
@@ -78,4 +78,7 @@ public class TraceOptions {
 	/** Eclipse clojure utilities related traces */
 	public static final String ECLIPSE = "/eclipse";
 
+	/** Clojure Editor related traces */
+	public static final String EDITOR = "/editor";
+
 }

--- a/ccw.core/src/java/ccw/util/BundleUtils.java
+++ b/ccw.core/src/java/ccw/util/BundleUtils.java
@@ -7,13 +7,15 @@ import org.eclipse.core.runtime.Status;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
+import ccw.CCWPlugin;
+import ccw.TraceOptions;
 import ccw.util.osgi.ClojureOSGi;
 import ccw.util.osgi.RunnableWithException;
 import clojure.lang.RT;
 import clojure.lang.Var;
 
 public final class BundleUtils {
-	
+
 	private BundleUtils() {
 		// Not intended to be instanciated
 	}
@@ -21,7 +23,7 @@ public final class BundleUtils {
 	/**
 	 * Returns the var corresponding to <code>varName</code>, requiring its
 	 * namespace first if not already present in memory.
-	 * 
+	 *
 	 * @param bundleSymbolicName the symbolic name of the bundle from which the
 	 *        namespace would be loaded, if so needed
 	 * @param varName fully qualified var name
@@ -39,26 +41,26 @@ public final class BundleUtils {
 					try {
 						return RT.var(nsName, nsFn[1]);
 					} catch( Exception e) {
-						System.out.println("Error while getting var " + varName);
+						String msg = String.format("Error while getting var %s", varName);
+						CCWPlugin.getTracer().trace(TraceOptions.CLOJURE_OSGI, msg);
 						throw e;
 					}
 				}
 			});
 		} catch (Exception e) {
-			System.out.println( 
-					"Problem requiring namespace/getting var " + varName 
-					+ " from bundle " + bundle.getSymbolicName());
-			IStatus status = new Status(IStatus.ERROR, bundle.getSymbolicName(), 
-					"Problem requiring namespace/getting var " + varName 
-					+ " from bundle " + bundle.getSymbolicName(), e);
+			String msg = String.format(
+					"Problem requiring namespace/getting var %s from bundle %s",
+					varName, bundle.getSymbolicName());
+			CCWPlugin.getTracer().trace(TraceOptions.CLOJURE_OSGI, e, msg);
+			IStatus status = new Status(IStatus.ERROR, bundle.getSymbolicName(), msg, e);
 			throw new CoreException(status);
 		}
 	}
-	
+
 	/**
 	 * Returns the var corresponding to <code>varName</code>, requiring its
 	 * namespace first if not already present in memory.
-	 * 
+	 *
 	 * @param bundleSymbolicName the symbolic name of the bundle from which the
 	 *        namespace would be loaded, if so needed
 	 * @param varName fully qualified var name
@@ -68,7 +70,7 @@ public final class BundleUtils {
 	public static Var requireAndGetVar(final String bundleSymbolicName, final String varName) throws CoreException {
 		return requireAndGetVar(loadAndGetBundle(bundleSymbolicName), varName);
 	}
-	
+
 	public static Bundle loadAndGetBundle(String bundleSymbolicName) throws CoreException {
 		// TODO: not good??, maybe we will not catch the right bundle (the same the OSGi framework would use ...)
 		try {
@@ -78,7 +80,7 @@ public final class BundleUtils {
 			}
 			return b;
 		} catch (BundleException e) {
-			IStatus status = new Status(IStatus.ERROR, bundleSymbolicName, 
+			IStatus status = new Status(IStatus.ERROR, bundleSymbolicName,
 					"Unable to start bundle", e);
 			throw new CoreException(status);
 		}

--- a/ccw.core/src/java/ccw/util/ClojureContributionFactorySpi.java
+++ b/ccw.core/src/java/ccw/util/ClojureContributionFactorySpi.java
@@ -35,7 +35,8 @@ public class ClojureContributionFactorySpi implements IContributionFactorySpi {
 	@Override
 	public Object create(final Bundle bundle, final String varAndParams,
 			final IEclipseContext context) {
-		CCWPlugin.getTracer().trace(TraceOptions.LOG_INFO, "create object for bundleclass://" + bundle.getSymbolicName() + "/" + "clojure" + "/" + varAndParams);
+		String msg = "create object for bundleclass://" + bundle.getSymbolicName() + "/" + "clojure" + "/" + varAndParams;
+		CCWPlugin.getTracer().trace(TraceOptions.LOG_INFO, msg);
 		try {
 			final String[] parts = varAndParams.split("\\/");
 			String var = parts[0] + "/" + parts[1];

--- a/ccw.core/src/java/ccw/util/NullTracer.java
+++ b/ccw.core/src/java/ccw/util/NullTracer.java
@@ -5,62 +5,31 @@ package ccw.util;
  */
 public final class NullTracer implements ITracer {
     public static final NullTracer INSTANCE = new NullTracer();
-    
+
     private NullTracer() {}
-    
-    public boolean isEnabled(String traceOption) { return true; }
 
-    public void trace(String traceOption, Object... message) {
-    	System.out.println("trace:" + traceOption + ", message:"
-    			+ Tracer.buildMessage(message));
-    }
+    @Override
+	public boolean isEnabled(String traceOption) { return false; }
 
-    public void trace(String traceOption, Throwable throwable, Object... message) {
-    	System.out.println("trace:" + traceOption + ", message:"
-    			+ Tracer.buildMessage(message));
-    	throwable.printStackTrace();
-    }
+    @Override
+	public void trace(String traceOption, Object... message) {}
 
-    public void traceDumpStack(String traceOption) {
-    	try {
-    		throw new RuntimeException("traceDumpStack:" + traceOption);
-    	} catch (RuntimeException e) {
-    		e.printStackTrace();
-    	}
-    }
+    @Override
+	public void trace(String traceOption, Throwable throwable, Object... message) {}
 
-    public void traceEntry(String traceOption) {
-    	try {
-    		throw new RuntimeException("traceEntry:" + traceOption);
-    	} catch (RuntimeException e) {
-    		e.printStackTrace();
-    	}
-    }
+    @Override
+	public void traceDumpStack(String traceOption) {}
 
-    public void traceEntry(String traceOption, Object... arguments) {
-    	try {
-    		throw new RuntimeException("traceEntry:" + traceOption
-    				+ ", arguments:" + Tracer.buildMessage(arguments));
-    	} catch (RuntimeException e) {
-    		e.printStackTrace();
-    	}
-    }
+    @Override
+	public void traceEntry(String traceOption) {}
 
-    public void traceExit(String traceOption) {
-    	try {
-    		throw new RuntimeException("traceExit:" + traceOption);
-    	} catch (RuntimeException e) {
-    		e.printStackTrace();
-    	}
-    }
+    @Override
+	public void traceEntry(String traceOption, Object... arguments) {}
 
-    public void traceExit(String traceOption, Object returnValue) {
-    	try {
-    		throw new RuntimeException("traceExit:" + traceOption 
-    				+ ", returnValue:" + returnValue);
-    	} catch (RuntimeException e) {
-    		e.printStackTrace();
-    	}
-    }
-    
+    @Override
+	public void traceExit(String traceOption) {}
+
+    @Override
+	public void traceExit(String traceOption, Object returnValue) {}
+
 }

--- a/ccw.core/src/java/ccw/util/Tracer.java
+++ b/ccw.core/src/java/ccw/util/Tracer.java
@@ -16,13 +16,12 @@ import org.osgi.framework.BundleContext;
  */
 public class Tracer implements ITracer {
 
-    private final String bundleSymbolicName;
+	private final String bundleSymbolicName;
 
-    private final PluginDebugOptionsListener traceOptionsListener = new PluginDebugOptionsListener();
+    private final PluginDebugOptionsListener traceOptionsListener;
 
     private class PluginDebugOptionsListener implements DebugOptionsListener {
-        @Override
-		public void optionsChanged(DebugOptions options) {
+        @Override public void optionsChanged(DebugOptions options) {
             if (options.isDebugEnabled()) {
                 debugTrace = options.newDebugTrace(bundleSymbolicName, Tracer.class);
             } else {
@@ -37,7 +36,8 @@ public class Tracer implements ITracer {
     private final Map<String, Boolean> options = new HashMap<String, Boolean>();
 
     public Tracer(final BundleContext bundleContext) {
-        this.bundleSymbolicName = bundleContext.getBundle().getSymbolicName();
+        bundleSymbolicName = bundleContext.getBundle().getSymbolicName();
+        traceOptionsListener = new PluginDebugOptionsListener();
         enableTracing(bundleContext);
     }
 
@@ -62,7 +62,7 @@ public class Tracer implements ITracer {
             return false;
         }
 
-        Boolean res = options.get(traceOption);
+        Boolean res = options.get(bundleSymbolicName + traceOption);
         if (res != null) {
             return res;
         } else {
@@ -81,49 +81,49 @@ public class Tracer implements ITracer {
     @Override
 	public void trace(String traceOption, Object... message) {
         if (isEnabled(traceOption)) {
-            debugTrace.trace("/" + traceOption, buildMessage(message));
+            debugTrace.trace(traceOption, buildMessage(message));
         }
     }
 
     @Override
 	public void trace(String traceOption, Throwable throwable, Object... message) {
         if (isEnabled(traceOption)) {
-            debugTrace.trace("/" + traceOption, buildMessage(message), throwable);
+            debugTrace.trace(traceOption, buildMessage(message), throwable);
         }
     }
 
     @Override
 	public void traceDumpStack(String traceOption) {
         if (isEnabled(traceOption)) {
-            debugTrace.traceDumpStack("/" + traceOption);
+            debugTrace.traceDumpStack(traceOption);
         }
     }
 
     @Override
 	public void traceEntry(String traceOption) {
         if (isEnabled(traceOption)) {
-            debugTrace.traceEntry("/" + traceOption);
+            debugTrace.traceEntry(traceOption);
         }
     }
 
     @Override
 	public void traceEntry(String traceOption, Object... arguments) {
         if (isEnabled(traceOption)) {
-            debugTrace.traceEntry("/" + traceOption, arguments);
+            debugTrace.traceEntry(traceOption, arguments);
         }
     }
 
     @Override
 	public void traceExit(String traceOption) {
         if (isEnabled(traceOption)) {
-            debugTrace.traceExit("/" + traceOption);
+            debugTrace.traceExit(traceOption);
         }
     }
 
     @Override
 	public void traceExit(String traceOption, Object returnValue) {
         if (isEnabled(traceOption)) {
-            debugTrace.traceExit("/" + traceOption, returnValue);
+            debugTrace.traceExit(traceOption, returnValue);
         }
     }
 

--- a/ccw.core/src/java/ccw/util/Tracer.java
+++ b/ccw.core/src/java/ccw/util/Tracer.java
@@ -15,13 +15,14 @@ import org.osgi.framework.BundleContext;
  * @author laurentpetit
  */
 public class Tracer implements ITracer {
-    
+
     private final String bundleSymbolicName;
 
     private final PluginDebugOptionsListener traceOptionsListener = new PluginDebugOptionsListener();
-    
+
     private class PluginDebugOptionsListener implements DebugOptionsListener {
-        public void optionsChanged(DebugOptions options) {
+        @Override
+		public void optionsChanged(DebugOptions options) {
             if (options.isDebugEnabled()) {
                 debugTrace = options.newDebugTrace(bundleSymbolicName, Tracer.class);
             } else {
@@ -30,18 +31,16 @@ public class Tracer implements ITracer {
             updateOptions(options);
         }
     }
-    
+
     private DebugTrace debugTrace = null;
 
     private final Map<String, Boolean> options = new HashMap<String, Boolean>();
-    
-    public Tracer(final BundleContext bundleContext, Map<String, Boolean> options) {
+
+    public Tracer(final BundleContext bundleContext) {
         this.bundleSymbolicName = bundleContext.getBundle().getSymbolicName();
-        this.options.putAll(options);
-        
         enableTracing(bundleContext);
     }
-    
+
     private void enableTracing(BundleContext context) {
         Dictionary<String, String> props = new Hashtable<String, String>();
         props.put(DebugOptions.LISTENER_SYMBOLICNAME, context.getBundle().getSymbolicName());
@@ -50,18 +49,19 @@ public class Tracer implements ITracer {
                 traceOptionsListener,
                 props);
     }
-    
+
     private void updateOptions(DebugOptions options) {
-        for (String option: this.options.keySet()) {
-            this.options.put(option, options.getBooleanOption(bundleSymbolicName + "/" + option, false));
+        for (String option: options.getOptions().keySet()) {
+            this.options.put(option, options.getBooleanOption(option, false));
         }
     }
-    
-    public boolean isEnabled(String traceOption) {
+
+    @Override
+	public boolean isEnabled(String traceOption) {
         if (debugTrace == null) {
             return false;
         }
-        
+
         Boolean res = options.get(traceOption);
         if (res != null) {
             return res;
@@ -77,87 +77,54 @@ public class Tracer implements ITracer {
         }
         return sb.toString();
     }
-    
-    public void trace(String traceOption, Object... message) {
-    	if (debugTrace != null)
-        debugTrace.trace("/" + traceOption, buildMessage(message));
-    	System.out.println(traceOption + ": " + buildMessage(message));
+
+    @Override
+	public void trace(String traceOption, Object... message) {
         if (isEnabled(traceOption)) {
             debugTrace.trace("/" + traceOption, buildMessage(message));
         }
     }
 
-    public void trace(String traceOption, Throwable throwable, Object... message) {
-    	if (debugTrace != null)
-        debugTrace.trace("/" + traceOption, buildMessage(message), throwable);
-    	System.out.println(traceOption + ": " + buildMessage(message) + ". Exception: " + throwable.getMessage());
-    	throwable.printStackTrace();
+    @Override
+	public void trace(String traceOption, Throwable throwable, Object... message) {
         if (isEnabled(traceOption)) {
             debugTrace.trace("/" + traceOption, buildMessage(message), throwable);
         }
     }
 
-    public void traceDumpStack(String traceOption) {
-    	if (debugTrace != null)
-        debugTrace.traceDumpStack("/" + traceOption);
-        System.out.println("trace dump stack: " + traceOption);
+    @Override
+	public void traceDumpStack(String traceOption) {
         if (isEnabled(traceOption)) {
             debugTrace.traceDumpStack("/" + traceOption);
         }
     }
 
-    public void traceEntry(String traceOption) {
-    	if (debugTrace != null)
-    	debugTrace.traceEntry("/" + traceOption);
-    	System.out.println("trace entry: " + traceOption);
+    @Override
+	public void traceEntry(String traceOption) {
         if (isEnabled(traceOption)) {
             debugTrace.traceEntry("/" + traceOption);
         }
     }
 
-    public void traceEntry(String traceOption, Object... arguments) {
-    	if (debugTrace != null)
-    	debugTrace.traceEntry("/" + traceOption, arguments);
-    	System.out.print("trace entry: " + traceOption);
-    	if (arguments != null) {
-    		System.out.print("[");
-    		boolean isFirst = true;
-    		for (Object o: arguments) {
-    			System.out.println(o);
-    			if (isFirst) {
-    				isFirst = false;
-    			} else {
-    				System.out.println(", ");
-    			}
-    		}
-    		System.out.print("]");
-    	}
-    	System.out.println();
+    @Override
+	public void traceEntry(String traceOption, Object... arguments) {
         if (isEnabled(traceOption)) {
             debugTrace.traceEntry("/" + traceOption, arguments);
         }
     }
 
-    public void traceExit(String traceOption) {
-    	if (debugTrace != null)
-    	debugTrace.traceExit("/" + traceOption);
-    	System.out.println("trace exit: " + traceOption);
+    @Override
+	public void traceExit(String traceOption) {
         if (isEnabled(traceOption)) {
             debugTrace.traceExit("/" + traceOption);
         }
     }
 
-    public void traceExit(String traceOption, Object returnValue) {
-    	if (debugTrace != null)
-        debugTrace.traceExit("/" + traceOption, returnValue);
-    	System.out.print("trace entry: " + traceOption);
-    	if (returnValue != null) {
-    		System.out.print("[" + returnValue + "]");
-    	}
-    	System.out.println();
+    @Override
+	public void traceExit(String traceOption, Object returnValue) {
         if (isEnabled(traceOption)) {
             debugTrace.traceExit("/" + traceOption, returnValue);
         }
     }
-    
+
 }

--- a/doc/src/documentation.adoc
+++ b/doc/src/documentation.adoc
@@ -504,3 +504,13 @@ This also demonstrates how to split a plugin into script + companion namespaces.
 
 WARNING: the `hello-world` subdirectory will only be recognized as a plugin if there is no `.clj` file inside `~/.ccw/`
 
+
+= Report a problem with Counterclockwise
+
+== Activate Tracing
+
+Counterclockwise can be more verbose on what's going on if you active `Tracing`.
+
+To activate Traces, follow this http://www.vogella.com/tutorials/EclipseCodeAccess/article.html#tracing_runonatruntime[good Lars Vogel's Tutorial]
+
+


### PR DESCRIPTION
- Refactoring of code
- Every trace option has documentation
- cross reference between `.options` and `TraceOptions.java` files
- `ccw.core/log/trace` has been renamed to the more conventional (in Eclipse world) `ccw.core/debug`

See #743 
