### PR TITLE
Re-enables tracing from Clojure source

### DIFF
--- a/ccw.core/src/java/ccw/util/ITracer.java
+++ b/ccw.core/src/java/ccw/util/ITracer.java
@@ -5,21 +5,112 @@ package ccw.util;
  * @author laurentpetit
  */
 public interface ITracer {
-	
+    /**
+     * Is the trace option enable?
+     * 
+     * <p>
+     * Options are NOT specified in the general form <i>&lt;Bundle-SymbolicName&gt;/&lt;option-path&gt;</i>
+     * but with the option path only, preceded by a forward slash: <i>/&lt;option-path&gt;</i>.
+     * For example <code>/debug</code> is good.
+     * </p>
+     * 
+     * @param traceOption A trace option, always option path only. For example: <code>/log/info</code>
+     * @return
+     */
     boolean isEnabled(String traceOption);
     
+    /**
+     * Trace method
+     * 
+     * <p>
+     * Options are NOT specified in the general form <i>&lt;Bundle-SymbolicName&gt;/&lt;option-path&gt;</i>
+     * but with the option path only, preceded by a forward slash: <i>/&lt;option-path&gt;</i>.
+     * For example <code>/debug</code> is good.
+     * </p>
+     * 
+     * @param traceOption A trace option, always option path only. For example: <code>/log/info</code>
+     * @param message One or more objects to be sent as trace message
+     */
     void trace(String traceOption, Object... message);
     
+    /**
+     * Trace method
+     * 
+     * <p>
+     * Options are NOT specified in the general form <i>&lt;Bundle-SymbolicName&gt;/&lt;option-path&gt;</i>
+     * but with the option path only, preceded by a forward slash: <i>/&lt;option-path&gt;</i>.
+     * For example <code>/debug</code> is good.
+     * </p>
+     * 
+     * @param traceOption A trace option, always option path only. For example: <code>/log/info</code>
+     * @param message One or more objects to be sent as trace message
+     * @param throwable A throwable
+     */
     void trace(String traceOption, Throwable throwable, Object... message);
     
+    /**
+     * Trace a dump stack.
+     * 
+     * <p>
+     * Options are NOT specified in the general form <i>&lt;Bundle-SymbolicName&gt;/&lt;option-path&gt;</i>
+     * but with the option path only, preceded by a forward slash: <i>/&lt;option-path&gt;</i>.
+     * For example <code>/debug</code> is good.
+     * </p>
+     * 
+     * @param traceOption A trace option, always option path only. For example: <code>/log/info</code>
+     */
     void traceDumpStack(String traceOption);
     
+    /**
+     * Trace an entry point.
+     * 
+     * <p>
+     * Options are NOT specified in the general form <i>&lt;Bundle-SymbolicName&gt;/&lt;option-path&gt;</i>
+     * but with the option path only, preceded by a forward slash: <i>/&lt;option-path&gt;</i>.
+     * For example <code>/debug</code> is good.
+     * </p>
+     * 
+     * @param traceOption A trace option, always option path only. For example: <code>/log/info</code>
+     */
     void traceEntry(String traceOption);
     
+    /**
+     * Trace an entry point.
+     * 
+     * <p>
+     * Options are NOT specified in the general form <i>&lt;Bundle-SymbolicName&gt;/&lt;option-path&gt;</i>
+     * but with the option path only, preceded by a forward slash: <i>/&lt;option-path&gt;</i>.
+     * For example <code>/debug</code> is good.
+     * </p>
+     * 
+     * @param traceOption A trace option, always option path only. For example: <code>/log/info</code>
+     */
     void traceEntry(String traceOption, Object... arguments);
 
+    /**
+     * Trace an exit point.
+     * 
+     * <p>
+     * Options are NOT specified in the general form <i>&lt;Bundle-SymbolicName&gt;/&lt;option-path&gt;</i>
+     * but with the option path only, preceded by a forward slash: <i>/&lt;option-path&gt;</i>.
+     * For example <code>/debug</code> is good.
+     * </p>
+     * 
+     * @param traceOption A trace option, always option path only. For example: <code>/log/info</code>
+     */
     void traceExit(String traceOption);
-    
+
+    /**
+     * Trace an exit point.
+     * 
+     * <p>
+     * Options are NOT specified in the general form <i>&lt;Bundle-SymbolicName&gt;/&lt;option-path&gt;</i>
+     * but with the option path only, preceded by a forward slash: <i>/&lt;option-path&gt;</i>.
+     * For example <code>/debug</code> is good.
+     * </p>
+     * 
+     * @param traceOption A trace option, always option path only. For example: <code>/log/info</code>
+     */
     void traceExit(String traceOption, Object returnValue);
 
 }


### PR DESCRIPTION
From the commit message:
The patch explores and fixes the reason why tracing from clj files was missing. On the Java side the
specification of tracing option with option path preceded by a forward slash worked but in
ccw.core.trace, or better ccw.trace macros, the forward slash was missing. Moreover, evident
warnings have been added as documentation in ITracer.

Note that it is absolutely necessary to specify the tracing option this way, as deep down
EclipseDebugTrace, a simple final String option = bundleSymbolicName + optionPath is performed.