### PR TITLE
fix(ClojureOSGi): narrowed down synchronized blocks to the strict nec…

### DIFF
--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -76,6 +76,7 @@ Counterclockwise ships with an embedded nREPL server. The following enhancements
 
 === User Plugins
 
+- Faster Eclipse Startup: with lots of user plugins installed, CCW used to freeze while the user plugins where launched. They are now launched in the background.
 - The keybinding cleaning function did concurrent modifications of an Eclipse Internal collection. Fix laurentpetit/ccw-plugin-manager#1
 
 == Changes between Counterclockwise 0.31.2 and 0.32.0

--- a/ccw.core/src/java/ccw/util/osgi/ClojureOSGi.java
+++ b/ccw.core/src/java/ccw/util/osgi/ClojureOSGi.java
@@ -19,6 +19,10 @@ public class ClojureOSGi {
 	private static volatile boolean initialized;
 	private synchronized static void initialize() {
 		if (initialized) return;
+		synchronizedInitialize();
+	}
+	private synchronized static void synchronizedInitialize() {
+		if (initialized) return;
 
 		CCWPlugin plugin = CCWPlugin.getDefault();
 		if (plugin == null) {
@@ -40,12 +44,12 @@ public class ClojureOSGi {
 		}
 
 	}
-	public synchronized static Object withBundle(Bundle aBundle, RunnableWithException aCode)
+	public static Object withBundle(Bundle aBundle, RunnableWithException aCode)
 			throws RuntimeException {
 		return withBundle(aBundle, aCode, null);
 	}
 
-	public synchronized static Object withBundle(Bundle aBundle, RunnableWithException aCode, List<URL> additionalURLs)
+	public static Object withBundle(Bundle aBundle, RunnableWithException aCode, List<URL> additionalURLs)
 			throws RuntimeException {
 
 		if (DisplayUtil.isUIThread()) {


### PR DESCRIPTION
…essary

Before, synchronized could cause deadlock between code calling require and
code calling withBundle

Fixes #761