### PR TITLE
Macro expansion hover

### DIFF
--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -73,6 +73,7 @@ Counterclockwise ships with an embedded nREPL server. The following enhancements
 === Hover Framework
 - New preference page for CCW hovers under menu:Preferences[Clojure > Editor > Hovers]. Keyboard modifiers can now been set for each hover.
 - Added the ability of contributing and configuring ITextHover* instances to Counterclockwise through the ccw.core.cljEditorTextHovers extension point.
+- Two hovers added: "Macro expansion" (using `macroexpand`) and "Recursive macro expansion" (using `macroexpand-all`), both leveraging `cider-nrepl` wrappers if found.
 
 === User Plugins
 

--- a/ccw.core/plugin.properties
+++ b/ccw.core/plugin.properties
@@ -160,6 +160,8 @@ docstringHover=Clojure Docstring
 docstringHoverDescription=Shows the docstring of the selected element.
 debugHover=Debug
 debugHoverDescription=Debug hover for testing.
+macroHover=Macro expansion
+macroHoverDescription=Aids Clojure macro expansion.
 
 Dummy.label=This dummy label is dedicated to all the contributors of org.eclipse.jdt.
 Presentation.label= Clojure

--- a/ccw.core/plugin.properties
+++ b/ccw.core/plugin.properties
@@ -156,7 +156,7 @@ ccw.leiningen.command.launch-headless-repl.description=Launch a Headless REPL fo
 
 cljEditorTextHoversName=Clojure Editor Text Hovers
 
-docstringHover=Clojure Docstring
+docstringHover=Clojure docstring
 docstringHoverDescription=Shows the docstring of the selected element.
 debugHover=Debug
 debugHoverDescription=Debug hover for testing.

--- a/ccw.core/plugin.properties
+++ b/ccw.core/plugin.properties
@@ -161,7 +161,9 @@ docstringHoverDescription=Shows the docstring of the selected element.
 debugHover=Debug
 debugHoverDescription=Debug hover for testing.
 macroHover=Macro expansion
-macroHoverDescription=Aids Clojure macro expansion.
+macroHoverDescription=Performs macroexpand and displays the result in a hover.
+macroHoverRecursive=Recursive macro expansion
+macroHoverRecursiveDescription=Performs macroexpand-all and displays the result in a hover.
 
 Dummy.label=This dummy label is dedicated to all the contributors of org.eclipse.jdt.
 Presentation.label= Clojure

--- a/ccw.core/plugin.xml
+++ b/ccw.core/plugin.xml
@@ -3443,6 +3443,20 @@
               </parameter>
             </run>
       </hover>-->
+      <hover
+            label="%macroHover"
+            description="%macroHoverDescription"
+            id="ccw.editors.clojure.hovers.macroHover"
+            activate="true"
+            modifier="Ctrl"
+            enabled="true">
+            <run class="ccw.util.GenericExecutableExtension">
+              <parameter
+                name="factory"
+                value="ccw.editors.clojure.hovers.macro-hover/create-macro-hover">
+              </parameter>
+            </run>
+      </hover>
    </extension>
    <extension
          point="org.eclipse.ui.themes">

--- a/ccw.core/plugin.xml
+++ b/ccw.core/plugin.xml
@@ -3453,8 +3453,26 @@
             <run class="ccw.util.GenericExecutableExtension">
               <parameter
                 name="factory"
-                value="ccw.editors.clojure.hovers.macro-hover/create-macro-hover">
-              </parameter>
+                value="ccw.editors.clojure.hovers.macro-hover/create-macro-hover"/>
+              <parameter
+                name="expander"
+                value="macroexpand"/>
+            </run>
+      </hover>
+      <hover
+            label="%macroHoverRecursive"
+            description="%macroHoverRecursiveDescription"
+            id="ccw.editors.clojure.hovers.macroHoverRecursive"
+            activate="true"
+            modifier="Ctrl-Shift"
+            enabled="true">
+            <run class="ccw.util.GenericExecutableExtension">
+              <parameter
+                name="factory"
+                value="ccw.editors.clojure.hovers.macro-hover/create-macro-hover"/>
+              <parameter
+                name="expander"
+                value="macroexpand-all"/>
             </run>
       </hover>
    </extension>

--- a/ccw.core/src/clj/ccw/editors/clojure/editor_common.clj
+++ b/ccw.core/src/clj/ccw/editors/clojure/editor_common.clj
@@ -57,11 +57,11 @@
 
 (defn send-message**
   "Send the message over the nrepl connection. This version is \"bare\", ie it
-   calls into the REPL without timeout protection. If you want to protect the 
+   calls into the REPL without timeout protection. If you want to protect the
    IDE to freeze if e.g. the REPL never times out, call send-message instead."
   [^Connection safe-connection message]
   (try
-    (-> safe-connection 
+    (-> safe-connection
       .getUnsafeConnection
       .client
       (repl/message message))
@@ -81,7 +81,7 @@
         result (deref secure-call timeout timeout-val)]
     (if (not= result timeout-val)
       result
-      (ccw.CCWPlugin/logError (str 
+      (ccw.CCWPlugin/logError (str
         "timeout while calling send-message** for message "
         (pr-str message))))))
 
@@ -94,7 +94,7 @@
     (when-let [r (apply send-message* safe-connection msg rest)]
      (repl/response-values r))))
 
-(def timed-out-safe-connections 
+(def timed-out-safe-connections
   "Keeps the timed out safe-connections in a map of [safe-connection nb-timeouts]"
   (atom {}))
 
@@ -164,22 +164,27 @@
   "Creates the context message"
   [callee-name callee-metadata]
   (when (some #{:arglists :doc} (keys callee-metadata))
-    (format "%s: %s\n%s" 
+    (format "%s: %s\n%s"
       callee-name
       (or (:arglists callee-metadata) "")
       (doc/slim-doc (:doc callee-metadata)))))
 
 (defmulti expand-macro-form
   "Multi method which expands a macro form using the middleware
-  supported by the input repl."
-  (fn [repl current-namespace form]
+  supported by the input repl. Expander must be a string, no check is
+  performed on the validity."
+  (fn [repl expander current-namespace form]
     (get-repl-available-op! repl "macroexpand")))
 
 (defmethod expand-macro-form :default
-  [repl current-namespace form]
+  [repl expander current-namespace form]
   (when repl
     (let [safe-connection (.getSafeToolingConnection repl)
-          code (str "(clojure.core/macroexpand '" form ")")]
+          expander-var (cond
+                         (= expander "macroexpand-all") "clojure.walk/macroexpand-all"
+                         :else "clojure.core/macroexpand")
+          code (str "(" expander-var " '" form ")")]
+      (t/trace :editor (str "Sending to current repl: " code))
       (first (send-code safe-connection code
                             ; we do not use session via send-code yet because
                             ; we cannot distinguish between clojure or clojurescript
@@ -188,17 +193,17 @@
                             )))))
 
 (defmethod expand-macro-form "macroexpand"
-  [repl current-namespace form]
+  [repl expander current-namespace form]
   (when repl
     (let [safe-connection (.getSafeToolingConnection repl)
-          response (-> (first
-                         (send-message safe-connection
-                           {"op" "macroexpand"
-                            "expander" "macroexpand"
-                            "code" form
-                            "ns" current-namespace
-                            "session" (.getSessionId repl)
-                            "display-namespaces" "tidy"}))
-                     (set/rename-keys {:arglists-str :arglists
-                                       :resource :file}))]
-      (:expansion response))))
+          op-data {"op" "macroexpand"
+                   "expander" expander
+                   "code" form
+                   "ns" current-namespace
+                   "session" (.getSessionId repl)
+                   "display-namespaces" "tidy"}]
+      (t/trace :editor (str "Sending to cider: " op-data))
+      (:expansion (-> (first
+                       (send-message safe-connection op-data))
+                      (set/rename-keys {:arglists-str :arglists
+                                        :resource :file}))))))

--- a/ccw.core/src/clj/ccw/editors/clojure/hover_support.clj
+++ b/ccw.core/src/clj/ccw/editors/clojure/hover_support.clj
@@ -302,8 +302,8 @@
       [hover result])))
 
 (defonce ^{:private true :doc "The common hover css."} hover-css
-  (memoize
-    (fn []
+  (delay
+    (do
       (trace :support/hover (str "Processing " StaticStrings/CCW_HOVER_CSS "..."))
       (slurp StaticStrings/CCW_HOVER_CSS))))
 
@@ -311,7 +311,7 @@
   "Prepend text to hover information."
   [hover-info]
   (let [buffer (java.lang.StringBuffer. hover-info)
-        prepend-text (HTMLPrinter/convertTopLevelFont (hover-css)
+        prepend-text (HTMLPrinter/convertTopLevelFont (force hover-css)
                                                       (aget (-> (JFaceResources/getFontRegistry)
                                                                 (.getFontData StaticStrings/CCW_HOVER_FONT)) 0))]
     (HTMLPrinter/insertPageProlog buffer 0 prepend-text)
@@ -343,10 +343,10 @@
                       (println "*** Dirty: " dirty)))))
 
 (defonce ^:private ^{:doc "Atom containing the state."}
-  state-atom (memoize (fn [] (atom (->State nil
-                                          (WritableList. (ArrayList.) HoverDescriptor)
-                                          nil
-                                          true)))))
+  state-atom (delay (atom (->State nil
+                                   (WritableList. (ArrayList.) HoverDescriptor)
+                                   nil
+                                   true))))
 
 (defn- swap-observable-descriptors
   "Updates the observable-hovers part of the state. Returns new state."
@@ -365,12 +365,12 @@
 (def ^:private contributed-descriptors
   "Var containing a function returning the contributed descriptors in
   the state."
-  #(:contributed-descriptors @(state-atom)))
+  #(:contributed-descriptors @(force state-atom)))
 
 (def ^:private observable-descriptors
   "Var containing a function returning the state observable descriptors
   in the state, for the Eclipse data binding framework."
-  #(:observable-descriptors @(state-atom)))
+  #(:observable-descriptors @(force state-atom)))
 
 (defn- state-dirty?
   [state]
@@ -394,12 +394,12 @@
 (defn- descriptors-update!
   "Updates the descriptors. Swaps in a new state, if necessary, returning the new one."
   []
-  (if (state-dirty? @(state-atom))
-    (let [new-state (swap! (state-atom) swap-descriptors-in-state (load-descriptors!))]
+  (if (state-dirty? @(force state-atom))
+    (let [new-state (swap! (force state-atom) swap-descriptors-in-state (load-descriptors!))]
       (trace :support/hover (str "State dirty, loaded:\n" new-state))
       new-state)
-    (do (trace :support/hover (str "State NOT dirty, returning:\n" @(state-atom)))
-        @(state-atom))))
+    (do (trace :support/hover (str "State NOT dirty, returning:\n" @(force state-atom)))
+        @(force state-atom))))
 
 
 ;;;;;;;;;;;;;;;;;
@@ -433,7 +433,7 @@
      (^void added [this #^"[Lorg.eclipse.core.runtime.IExtension;" extensions]
        (doseq [^IExtension ex extensions] (trace :support/hover (str "IRegistryEventListener added extension with id: " (.getLabel ex))))
        (trace :support/hover "Resetting hovers...")
-       (swap! (state-atom) set-state-dirty)
+       (swap! (force state-atom) set-state-dirty)
        (descriptors-update!)
        ;; I need some protection because here i might not have active editor
        (some-> (CCWPlugin/getClojureEditor) reset-default-hover-on-editor!))
@@ -441,7 +441,7 @@
      (^void removed [this #^"[Lorg.eclipse.core.runtime.IExtension;" extensions]
        (doseq [^IExtension ex extensions] (trace :support/hover (str "IRegistryEventListener removed extension with id: " (.getLabel ex))))
        (trace :support/hover "Resetting hovers...")
-       (swap! (state-atom) set-state-dirty)
+       (swap! (force state-atom) set-state-dirty)
        (descriptors-update!)
        ;; I need some protection because here i might not have active editor
        (some-> (CCWPlugin/getClojureEditor) reset-default-hover-on-editor!))
@@ -449,7 +449,7 @@
      (^void added [this #^"[Lorg.eclipse.core.runtime.IExtensionPoint;" extension-points]
        (doseq [^IExtensionPoint ep extension-points] (trace :support/hover (str "IRegistryEventListener added extension point with id: " (.getLabel ep))))
        (trace :support/hover "Resetting hovers...")
-       (swap! (state-atom) set-state-dirty)
+       (swap! (force state-atom) set-state-dirty)
        (descriptors-update!)
        ;; I need some protection because here i might not have active editor
        (some-> (CCWPlugin/getClojureEditor) reset-default-hover-on-editor!))
@@ -457,7 +457,7 @@
      (^void removed [this #^"[Lorg.eclipse.core.runtime.IExtensionPoint;" extension-points]
        (doseq [^IExtensionPoint ep extension-points] (trace :support/hover (str "IRegistryEventListener removed extension point with id: " (.getLabel ep))))
        (trace :support/hover "Resetting hovers...")
-       (swap! (state-atom) set-state-dirty)
+       (swap! (force state-atom) set-state-dirty)
        (descriptors-update!)
        ;; I need some protection because here i might not have active editor
        (some-> (CCWPlugin/getClojureEditor) reset-default-hover-on-editor!)))
@@ -471,7 +471,7 @@
     (ccw.eclipse/add-preference-listener pref-key
                                          #(do
                                             (trace :support/hover (str "Preference " pref-key " has changed. Resetting hovers..."))
-                                            (swap! (state-atom) set-state-dirty)
+                                            (swap! (force state-atom) set-state-dirty)
                                             ;; I need some protection because here i might not have active editor
                                             (some-> (CCWPlugin/getClojureEditor) reset-default-hover-on-editor!)))))
 
@@ -523,7 +523,7 @@
     ;; ensure non nil descriptor arrives here
     (let [state-mask (selected-descriptor :state-mask)]
       (do-if-no-value descriptors state-mask
-                      (swap! (state-atom) swap-hover-instance-in-state state-mask __a_value)
+                      (swap! (force state-atom) swap-hover-instance-in-state state-mask __a_value)
                       ((selected-descriptor :create-hover))))))
 
 (defn hover-instance
@@ -562,7 +562,7 @@
         (trace :support/hover (str (simple-name this) ": offset-> " offset))
         (let [[_ region] (hover-result-pair #(.getHoverRegion %1 text-viewer offset)
                                             (complement nil?)
-                                            (:hovers-by-state-mask @(state-atom))
+                                            (:hovers-by-state-mask @(force state-atom))
                                             @previous-hover
                                             (fn [[hover _]] (reset! previous-hover hover)))]
           region))

--- a/ccw.core/src/clj/ccw/editors/clojure/hover_support.clj
+++ b/ccw.core/src/clj/ccw/editors/clojure/hover_support.clj
@@ -62,7 +62,8 @@
                                  preference!
                                  ccw-combined-prefs
                                  workbench-active-editor]]
-            [ccw.editors.clojure.editor-support :refer [source-viewer set-status-line-error-msg-async]]
+            [ccw.editors.clojure.editor-support :refer [source-viewer
+                                                        set-status-line-error-msg-async]]
             [ccw.core.trace :refer [trace]]
             [ccw.extensions :refer [configuration-elements
                                     attributes->map

--- a/ccw.core/src/java/ccw/editors/clojure/ClojureEditor.java
+++ b/ccw.core/src/java/ccw/editors/clojure/ClojureEditor.java
@@ -480,29 +480,36 @@ public class ClojureEditor extends TextEditor implements IClojureEditor {
 			selectAndReveal(r.getOffset(), r.getLength());
 	}
 
-	private IRegion getTopLevelSExpression() {
+	private @Nullable IRegion getTopLevelSExpression() {
 		if (!checkSelectionAndWarnUserIfProblem(ClojureEditorMessages.GotoMatchingBracketAction_error_invalidSelection))
 			return null;
 
-		int sourceCaretOffset = getSourceCaretOffset();
-		
-		int endOffset = getEndOfCurrentOrNextTopLevelSExpressionFor(sourceCaretOffset);
-		int beginningOffset = getBeginningOfCurrentOrPrecedingTopLevelSExpressionFor(endOffset);
-
-		if (beginningOffset>=0 && endOffset>=0) {
-			// length made to not include end position but
-			// (end position - 1)
-			int length = endOffset - beginningOffset;
-			return new Region(beginningOffset, length);
-		} else {
-			return null;
-		}
+		return getTopLevelRegion(getSourceCaretOffset());
 	}
 
-	public String getCurrentTopLevelSExpression() {
-		return (String) editorSupport._("top-level-code-form", getParseState(), getSourceCaretOffset());
-	}
-	
+    public String getCurrentTopLevelSExpression() {
+        return sourceViewer().getTopLevelSExpression(getSourceCaretOffset());
+    }
+
+    @Override
+    public String getTopLevelSExpression(final int caretOffset) {
+        return sourceViewer().getTopLevelSExpression(caretOffset);
+    }
+
+    private @Nullable IRegion getTopLevelRegion(final int caretOffset) {
+        int endOffset = getEndOfCurrentOrNextTopLevelSExpressionFor(caretOffset);
+        int beginningOffset = getBeginningOfCurrentOrPrecedingTopLevelSExpressionFor(endOffset);
+
+        if (beginningOffset>=0 && endOffset>=0) {
+            // length made to not include end position but
+            // (end position - 1)
+            int length = endOffset - beginningOffset;
+            return new Region(beginningOffset, length);
+        } else {
+            return null;
+        }
+    }
+    
 	/**
 	 * Move to end of current or following defun (end-of-defun).
 	 */

--- a/ccw.core/src/java/ccw/editors/clojure/ClojureEditorMessages.java
+++ b/ccw.core/src/java/ccw/editors/clojure/ClojureEditorMessages.java
@@ -79,8 +79,9 @@ public final class ClojureEditorMessages extends NLS {
     public static String ShowInformation_description;
     public static String ShowInformation_image;
     
-    public static String HoverInfo_args_label;
-    public static String HoverInfo_doc_label;
+    public static String DocUtils_args_label;
+    public static String DocUtils_doc_label;
+    public static String DocUtils_macro_label;
     
     static {
         NLS.initializeMessages(BUNDLE_NAME, ClojureEditorMessages.class);

--- a/ccw.core/src/java/ccw/editors/clojure/ClojureEditorMessages.properties
+++ b/ccw.core/src/java/ccw/editors/clojure/ClojureEditorMessages.properties
@@ -48,5 +48,6 @@ ShowInformation_tooltip=Shows information for the current symbol
 ShowInformation_image=
 ShowInformation_description=Displays a hover containing information for the current caret location
 
-HoverInfo_args_label=Argument Lists
-HoverInfo_doc_label=Documentation
+DocUtils_args_label=Argument Lists
+DocUtils_doc_label=Documentation
+DocUtils_macro_label=&#8645;

--- a/ccw.core/src/java/ccw/editors/clojure/ClojureSourceViewer.java
+++ b/ccw.core/src/java/ccw/editors/clojure/ClojureSourceViewer.java
@@ -676,5 +676,9 @@ public abstract class ClojureSourceViewer extends ProjectionViewer implements IC
         fPreferenceStore.removePropertyChangeListener(listener);
     }
 
-	
+    @Override
+    public @Nullable String getTopLevelSExpression(int caretOffset) {
+        String form = (String) editorSupport._("top-level-code-form", getParseState(), caretOffset);
+        return form;
+    }
 }

--- a/ccw.core/src/java/ccw/editors/clojure/ClojureSourceViewer.java
+++ b/ccw.core/src/java/ccw/editors/clojure/ClojureSourceViewer.java
@@ -55,12 +55,18 @@ import ccw.ClojureCore;
 import ccw.core.IPropertyPublisher;
 import ccw.editors.clojure.scanners.ClojurePartitionScanner;
 import ccw.preferences.PreferenceConstants;
-import ccw.repl.REPLView;
-import ccw.repl.SafeConnection;
+import ccw.repl.IReplProvider;
 import ccw.util.ClojureInvoker;
 import ccw.util.DisplayUtil;
 
-public abstract class ClojureSourceViewer extends ProjectionViewer implements IClojureEditor, IPropertyPublisher {
+/**
+ * The Counterclockwise SourceViewer.<br/>
+ * <br/>
+ * <i>Note: the IReplProvider is only temporarily part of the contract of this class, as it does not make sense to have a SourceViewer as Repl provider.
+ * It is necessary at the moment because the SourceViewer is passed to ITextHover (and extensions) in input and in turn ITextHover implementations needs a Repl.
+ * This will be reworked soon in some better way.</i>
+ */
+public abstract class ClojureSourceViewer extends ProjectionViewer implements IClojureEditor, IReplProvider, IPropertyPublisher {
 
 	private final ClojureInvoker editorSupport = ClojureInvoker.newInvoker(
             CCWPlugin.getDefault(),
@@ -454,16 +460,6 @@ public abstract class ClojureSourceViewer extends ProjectionViewer implements IC
         return null;
     }
 
-    public @Nullable REPLView getCorrespondingREPL () {
-        // this gets overridden in REPLView as appropriate so that the toolConnection there gets returned
-        return null;
-    }
-    
-    public @Nullable SafeConnection getSafeToolingConnection () {
-        // this gets overridden in REPLView as appropriate so that the toolConnection there gets returned
-        return null;
-    }
-    
     public void updateTabsToSpacesConverter () {}
     
     // TODO get rid of this way of handling document initialization

--- a/ccw.core/src/java/ccw/editors/clojure/IClojureEditor.java
+++ b/ccw.core/src/java/ccw/editors/clojure/IClojureEditor.java
@@ -130,4 +130,11 @@ public interface IClojureEditor extends IAdaptable {
 	 * Initializes the viewer colors, adding them in the color cache.
 	 */
 	void initializeViewerColors();
+
+	/**
+	 * Given an offset, returns its top level sexp.
+	 * @param caretOffset The offset.
+	 * @return The top level sexp.
+	 */
+	@Nullable String getTopLevelSExpression(final int caretOffset);
 }

--- a/ccw.core/src/java/ccw/editors/clojure/IClojureEditor.java
+++ b/ccw.core/src/java/ccw/editors/clojure/IClojureEditor.java
@@ -9,9 +9,6 @@ import org.eclipse.jface.text.source.DefaultCharacterPairMatcher;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 
-import ccw.repl.REPLView;
-import ccw.repl.SafeConnection;
-
 /**
  * A callback interface allowing various facilities to treat
  * the {@link ClojureEditor} and {@link ClojureSourceViewer}
@@ -84,17 +81,6 @@ public interface IClojureEditor extends IAdaptable {
 
     Object getParseState ();
     Object getPreviousParseTree ();
-    
-    /**
-     * Can be null...
-     */
-    @Nullable REPLView getCorrespondingREPL();
-        
-    /**
-     * Gets the connection.
-     * @return The connection, or null if none
-     */
-    @Nullable SafeConnection getSafeToolingConnection();
     
     /**
 	 * Install/uninstall the Tab-to-Space converter.

--- a/ccw.core/src/java/ccw/editors/clojure/hovers/Messages.java
+++ b/ccw.core/src/java/ccw/editors/clojure/hovers/Messages.java
@@ -6,6 +6,7 @@ public class Messages extends NLS {
     private static final String BUNDLE_NAME = "ccw.editors.clojure.hovers.messages";
     
     public static String You_need_a_running_repl_docstring;
+    public static String You_need_a_running_repl_macro;
     
     static {
         // initialize resource bundle

--- a/ccw.core/src/java/ccw/editors/clojure/hovers/messages.properties
+++ b/ccw.core/src/java/ccw/editors/clojure/hovers/messages.properties
@@ -1,1 +1,2 @@
 You_need_a_running_repl_docstring=No info found - You might need a running REPL to show the documentation
+You_need_a_running_repl_macro=Cannot perform macro expansion - You might need a running REPL

--- a/ccw.core/src/java/ccw/repl/IReplProvider.java
+++ b/ccw.core/src/java/ccw/repl/IReplProvider.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Laurent Petit.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: 
+ *    Andrea RICHIARDI - initial implementation
+ *******************************************************************************/
+package ccw.repl;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Repl provider contract.
+ */
+public interface IReplProvider {
+
+    /**
+     * Gets the corresponding Repl of this object.
+     * @return The Repl(View), can be null...
+     */
+    @Nullable REPLView getCorrespondingREPL();
+    
+    /**
+     * Gets the connection.
+     * @return The connection, or null if none
+     */
+    @Nullable SafeConnection getSafeToolingConnection();
+}

--- a/ccw.core/src/java/ccw/util/UiUtils.java
+++ b/ccw.core/src/java/ccw/util/UiUtils.java
@@ -7,12 +7,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.action.Action;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Device;
-import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
@@ -179,15 +174,5 @@ public class UiUtils {
                 (int) (complement * bg.blue + factor * fg.blue)
         );
         
-    }
-    
-    public static Point estimateSizeHint(Device device, Font font, String text) {
-        // Fake widget
-        TextLayout t = new TextLayout(device);
-        t.setFont(font);
-        t.setText(text);
-        
-        Rectangle bounds = t.getBounds();
-        return new Point(bounds.x + bounds.width, bounds.y + bounds.height);
     }
 }


### PR DESCRIPTION
Hello Laurent,
I so like this addition :smile:  I still have some problem with the size of the html hover with ```<pre>``` tags, but I am going to try some other hack to make it work...nonetheless, it correctly shows hover expansion...and I reckon it can be very useful for users.

Form the git message:

    a second hover, which performs macro expansion if a repl is available, has been added to the group.
    It expands using either the standard clojure.core/macroexpand method or cider-nrepl middleware (which has been configured with display-namespaces=tidy).
    The Macro hover has default key modifier set to Ctrl.

