### PR TITLE
Osgi fixes

### DIFF
--- a/ccw.core/src/java/ccw/util/osgi/ClojureOSGi.java
+++ b/ccw.core/src/java/ccw/util/osgi/ClojureOSGi.java
@@ -81,7 +81,7 @@ public class ClojureOSGi {
 	public static Object withBundle(Bundle aBundle, RunnableWithException aCode, List<URL> additionalURLs)
 			throws RuntimeException {
 
-		if (Thread.currentThread().isInterrupted() || CCWPlugin.canLoadCodeInBundle()) {
+		if (Thread.currentThread().isInterrupted() || !CCWPlugin.canLoadCodeInBundle()) {
 			return null;
 		}
 		

--- a/ccw.core/src/java/ccw/util/osgi/ClojureOSGi.java
+++ b/ccw.core/src/java/ccw/util/osgi/ClojureOSGi.java
@@ -16,12 +16,11 @@ import clojure.lang.Compiler;
 import clojure.lang.DynamicClassLoader;
 import clojure.lang.IPersistentMap;
 import clojure.lang.RT;
-import clojure.lang.Symbol;
 import clojure.lang.Var;
 
 public class ClojureOSGi {
 	private static volatile boolean initialized;
-	private synchronized static void initialize() {
+	private static void initialize() {
 		if (initialized) return;
 		synchronizedInitialize();
 	}

--- a/ccw.core/src/java/ccw/util/osgi/ClojureOSGi.java
+++ b/ccw.core/src/java/ccw/util/osgi/ClojureOSGi.java
@@ -81,6 +81,10 @@ public class ClojureOSGi {
 	public static Object withBundle(Bundle aBundle, RunnableWithException aCode, List<URL> additionalURLs)
 			throws RuntimeException {
 
+		if (Thread.currentThread().isInterrupted() || CCWPlugin.canLoadCodeInBundle()) {
+			return null;
+		}
+		
 		initialize();
 
 		DynamicClassLoader loader = getDynamicClassLoader(aBundle, additionalURLs);


### PR DESCRIPTION
Hello Laurent,
I added the two fixes discussed in #769 and #767 (actually the ```synchronized``` comment is somewhere I cannot find anymore).

The first just removes ```synchronized``` from ```ClojureOSGi.initialize()```, the second solves the exception:

    !ENTRY org.eclipse.osgi 2 0 2015-05-17 10:08:59.544
    !MESSAGE State change in progress for bundle "reference:file:/home/***/git/ccw/ccw.core/" by thread "main".
    !STACK 0
    org.osgi.framework.BundleException: State change in progress for bundle "reference:file:/home/***/git/ccw/ccw.core/" by thread "main".
    at org.eclipse.osgi.framework.internal.core.AbstractBundle.beginStateChange(AbstractBundle.java:1088)
	at org.eclipse.osgi.framework.internal.core.AbstractBundle.start(AbstractBundle.java:298)
	at org.eclipse.osgi.framework.util.SecureAction.start(SecureAction.java:478)

I hope I have not messed up with it too much :wink: 