### PR TITLE
Display exec simplifications

### DIFF
--- a/ccw.core/src/clj/ccw/repl/view_helpers.clj
+++ b/ccw.core/src/clj/ccw/repl/view_helpers.clj
@@ -22,7 +22,7 @@
   [f] (swt/ui-sync f))
 
 (defn ^:deprecated beep
-  "deprecated - use ccw.swt/ui-sync instead. Executes a beep sound"
+  "deprecated - use ccw.swt/beep instead. Executes a beep sound"
   [] (swt/beep))
 
 (defn- set-style-range

--- a/ccw.core/src/clj/ccw/swt.clj
+++ b/ccw.core/src/clj/ccw/swt.clj
@@ -94,6 +94,12 @@
 (import 'org.eclipse.swt.widgets.Display)
 (import 'org.eclipse.swt.widgets.Shell)
 
+(defn display [] (Display/getCurrent))
+
+(defn active-shell []
+  (-> (org.eclipse.swt.widgets.Display/getDefault)
+    .getActiveShell))
+
 (defmacro ui
   [& body]
   `(if (Display/getCurrent)
@@ -106,12 +112,6 @@
 ;       (fn []
 ;         (let [~display-name (Display/getCurrent)]
 ;           ~@body)))))
-
-(defn display [] (Display/getCurrent))
-
-(defn active-shell []
-  (-> (org.eclipse.swt.widgets.Display/getDefault)
-    .getActiveShell))
 
 (defn ui-async
   "Executes f asynchronously (non-blocking) on the user-interface thread"

--- a/ccw.core/src/clj/ccw/swt.clj
+++ b/ccw.core/src/clj/ccw/swt.clj
@@ -123,24 +123,25 @@
   [f]
   (DisplayUtil/syncExec f))
 
-(defn ui*
-  "Calls f with (optionally) args on the UI Thread, using
-   Display/asyncExec.
-   Return a promise which can be used to get back the
-   eventual result of the execution of f.
-   If calling f throws an Exception, the exception itself is delivered
-   to the promise."
-  [f & args]
-  (let [a (promise)]
-    (DisplayUtil/asyncExec #(deliver a (try
-                                         (apply f args)
-                                         (catch Exception e e))))
-    a))
-
-(defmacro do-ui* [& args]
-  `(if (org.eclipse.swt.widgets.Display/getCurrent)
-     (atom (do ~@args))
-     (ui* (fn [] ~@args))))
+;; not called anymore: remove?
+;(defn ui*
+;  "Calls f with (optionally) args on the UI Thread, using
+;   Display/asyncExec.
+;   Return a promise which can be used to get back the
+;   eventual result of the execution of f.
+;   If calling f throws an Exception, the exception itself is delivered
+;   to the promise."
+;  [f & args]
+;  (let [a (promise)]
+;    (DisplayUtil/asyncExec #(deliver a (try
+;                                         (apply f args)
+;                                         (catch Exception e e))))
+;    a))
+;
+;(defmacro do-ui* [& args]
+;  `(if (org.eclipse.swt.widgets.Display/getCurrent)
+;     (atom (do ~@args))
+;     (ui* (fn [] ~@args))))
 
 (defn beep
   "Executes a beep sound"


### PR DESCRIPTION
This PR contains work on simplifying swt/ui swt/ui-sync swt/ui-sync, swt/do-ui* swt/do-ui

- remove `swt/ui`, `swt/do-ui`, `swt/do-ui*`
- rename `swt/ui-sync` to `swt/dosync`
- rename `swt/ui-async` to `swt/doasync`
- create `swt/dosync*` and `swt/doasync*` which are functional counterparts of the macros

Write great docstrings for these functions.

- Make `swt/dosync` return a value.
- Make `swt/doasync` return a promise for a value.
