### PR TITLE
fix(scanners): add rule for correctly parsing a Clojure char

### DIFF
--- a/ccw.core/plugin.xml
+++ b/ccw.core/plugin.xml
@@ -120,6 +120,14 @@
    </extension>
    <extension point="org.eclipse.debug.core.launchConfigurationTypes">
       <launchConfigurationType
+            delegate="ccw.launching.EnhancedJavaLaunchDelegate"
+            delegateName="Enhanced Java Launcher"
+            id="ccw.launching.enhanced-java"
+            modes="run, debug"
+            name="Enhanced Java Launch"
+            public="false">
+      </launchConfigurationType>
+      <launchConfigurationType
             delegate="ccw.launching.ClojureLaunchDelegate"
             delegateName="Clojure Launcher"
             id="ccw.launching.clojure"

--- a/ccw.core/src/clj/ccw/launch.clj
+++ b/ccw.core/src/clj/ccw/launch.clj
@@ -14,7 +14,8 @@
                                    ILaunchesListener2
                                    IStreamListener]
            [org.eclipse.debug.core.model IProcess]
-           [org.eclipse.debug.core.sourcelookup ISourcePathComputer]))
+           [org.eclipse.debug.core.sourcelookup ISourcePathComputer]
+           [ccw.launching          EnhancedJavaLaunchDelegate]))
 
 ;;;; UTILITY FOR JDT
   ;; Specify a classpath. This is more or less easy depending on where it comes from
@@ -70,7 +71,9 @@
   "Pre-defined types of launch configurations"
   {:ccw 
      "ccw.launching.clojure"
-   :java 
+   :java ;; enhanced LaunchDelegate based on the :java launcher  
+     EnhancedJavaLaunchDelegate/ID_JAVA_APPLICATION
+   :raw-java 
      IJavaLaunchConfigurationConstants/ID_JAVA_APPLICATION
    :remote-java
      IJavaLaunchConfigurationConstants/ID_REMOTE_JAVA_APPLICATION})

--- a/ccw.core/src/clj/ccw/launching/enhanced_java_launch_delegate.clj
+++ b/ccw.core/src/clj/ccw/launching/enhanced_java_launch_delegate.clj
@@ -1,0 +1,58 @@
+;*******************************************************************************
+;* Copyright (c) 2015 Laurent PETIT.
+;* All rights reserved. This program and the accompanying materials
+;* are made available under the terms of the Eclipse Public License v1.0
+;* which accompanies this distribution, and is available at
+;* http://www.eclipse.org/legal/epl-v10.html
+;*
+;* Contributors:
+;*    Laurent PETIT - initial implementation
+;*******************************************************************************/
+(ns ccw.launching.enhanced-java-launch-delegate
+  "Small enhancements over JavaLaunchDelegate:
+   - Fix OS X not propagating environment variables: add additional PATHs to the PATH"
+  (:import [org.eclipse.core.runtime Platform]
+           [org.eclipse.debug.core DebugPlugin]
+           [org.eclipse.osgi.service.environment Constants]))
+
+(defn osx?
+  "Is the running platform Mac OS X ?"
+  []
+  (= (Platform/getOS) Constants/OS_MACOSX))
+
+(defn build-osx-base-environment
+  "Builds the base environment variables map. This function would not
+   work on windows (not as sophisticated as the one found in LaunchManager"
+  []
+  (assert (osx?))
+  (let [launch-manager (-> (DebugPlugin/getDefault) .getLaunchManager)]
+    (into {} (.getNativeEnvironmentCasePreserved launch-manager))))
+
+(defn env-array->env-map
+  "Transforms an Array of '{k}={v}' Strings to {k v} map"
+  [env]
+  (letfn [(key-val [s] (let [[_ k v] (re-find #"([^=]*)=(.*)" s)]
+                         [k v]))]
+    (->> env
+      (map key-val)
+      (reduce (fn [m [k v]] (assoc m k v)) {}))))
+
+(defn env-map->array
+  "The Eclipse API wants an Array of String, so let's give it what it wants"
+  [env-map]
+  (into-array String
+    (->> env-map (map (fn [[k v]] (str k "=" v))))))
+
+(defn get-environment
+  "Appends some classic missing PATH environment variable values in OS X."
+  [delegate configuration]
+  (let [env (.superGetEnvironment delegate configuration)]
+    (if-not (osx?)
+      env
+      (let [env-map (or (some-> env env-array->env-map)
+                        (build-osx-base-environment))]
+        (-> env-map
+          (update-in ["PATH"]
+            (fnil str "/usr/bin:/bin:/usr/sbin:/sbin")
+            ":/usr/local/bin") ;; "/usr/local/bin" is the one missing in some OS X configs
+          env-map->array)))))

--- a/ccw.core/src/java/ccw/editors/clojure/scanners/ClojurePartitionScanner.java
+++ b/ccw.core/src/java/ccw/editors/clojure/scanners/ClojurePartitionScanner.java
@@ -15,12 +15,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jface.text.rules.EndOfLineRule;
-import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IToken;
 import org.eclipse.jface.text.rules.MultiLineRule;
 import org.eclipse.jface.text.rules.RuleBasedPartitionScanner;
 import org.eclipse.jface.text.rules.Token;
+
+import ccw.editors.clojure.scanners.rules.ClojureCharRule;
 
 public class ClojurePartitionScanner extends RuleBasedPartitionScanner {
 	public static final String CLOJURE_PARTITIONING = "__clojure_partitioning";
@@ -46,67 +47,4 @@ public class ClojurePartitionScanner extends RuleBasedPartitionScanner {
          
         setPredicateRules(rules.toArray(new IPredicateRule[rules.size()]));
     }
-    
-    public static class ClojureCharRule implements IPredicateRule {
-    	private final IToken tokenToReturn;
-    	public ClojureCharRule(IToken tokenToReturn) {
-    		this.tokenToReturn = tokenToReturn; 
-    	}
-
-		public IToken evaluate(ICharacterScanner scanner, boolean resume) {
-			if (resume == true) {
-				throw new IllegalArgumentException("unhandled case when resume = true");
-			} else {
-				return evaluate(scanner);
-			}
-		}
-
-		public IToken getSuccessToken() {
-			return tokenToReturn;
-		}
-
-		public IToken evaluate(ICharacterScanner scanner) {
-			int firstChar = scanner.read();
-			if ((char)firstChar != '\\') {
-				scanner.unread();
-				return Token.UNDEFINED;
-			} else {
-				int next = scanner.read();
-				if (Character.isWhitespace(next)) {
-					scanner.unread();
-					return Token.UNDEFINED;
-				}
-//				if ((char)next == 'n') {
-//					int second = scanner.read();
-//					if ((char)second != 'e') {
-//						scanner.unread();
-//						return getSuccessToken();
-//					} else {
-//						
-//					}
-//				}
-//				if ((char)next == 's') {
-//					int second = scanner.read();
-//					if ((char)second != 'p') {
-//						scanner.unread();
-//						return getSuccessToken();
-//					} else {
-//						
-//					}
-//				}
-//				if ((char)next == 't') {
-//					int second = scanner.read();
-//					if ((char)second != 'a') {
-//						scanner.unread();
-//						return getSuccessToken();
-//					} else {
-//						
-//					}
-//				}
-				return getSuccessToken();
-			}
-		}
-    	
-    }
-    
 }

--- a/ccw.core/src/java/ccw/editors/clojure/scanners/ClojureTokenScanner.java
+++ b/ccw.core/src/java/ccw/editors/clojure/scanners/ClojureTokenScanner.java
@@ -66,7 +66,6 @@ public final class ClojureTokenScanner implements ITokenScanner, IPropertyChange
 
     private IClojureEditor clojureEditor;
     private IPreferenceStore preferenceStore;
-    private TokenScannerUtils utils;
     
     protected static final IToken errorToken = new org.eclipse.jface.text.rules.Token(new TextAttribute(Display.getDefault().getSystemColor(SWT.COLOR_WHITE), Display.getDefault().getSystemColor(SWT.COLOR_DARK_RED), TextAttribute.UNDERLINE));
     private int currentParenLevel = 0;
@@ -94,24 +93,23 @@ public final class ClojureTokenScanner implements ITokenScanner, IPropertyChange
         this.preferenceStore = preferenceStore;
         this.clojureEditor = clojureEditor;
         parserTokenKeywordToJFaceToken = new HashMap<Keyword, IToken>();
-        utils = new TokenScannerUtils(this);
-        initClojureTokenTypeToJFaceTokenMap(utils);
+        initClojureTokenTypeToJFaceTokenMap();
     }
 
-	protected void initClojureTokenTypeToJFaceTokenMap(TokenScannerUtils u) {
-		u.addTokenType(Keyword.intern("unexpected"), ClojureTokenScanner.errorToken);
-		u.addTokenType(Keyword.intern("eof"), Token.EOF);
-		u.addTokenType(Keyword.intern("whitespace"), Token.WHITESPACE);
+    protected void initClojureTokenTypeToJFaceTokenMap() {
+        TokenScannerUtils.addTokenType(this, Keyword.intern("unexpected"), ClojureTokenScanner.errorToken);
+        TokenScannerUtils.addTokenType(this, Keyword.intern("eof"), Token.EOF);
+        TokenScannerUtils.addTokenType(this, Keyword.intern("whitespace"), Token.WHITESPACE);
 
-		for (Keyword token: PreferenceConstants.colorizableTokens) {
-			PreferenceConstants.ColorizableToken tokenStyle = PreferenceConstants.getColorizableToken(preferenceStore, token);
-			u.addTokenType(
-					token,
-					StringConverter.asString(tokenStyle.rgb),
-					tokenStyle.isBold,
-					tokenStyle.isItalic);
-		}
-	}
+        for (Keyword token: PreferenceConstants.colorizableTokens) {
+            PreferenceConstants.ColorizableToken tokenStyle = PreferenceConstants.getColorizableToken(preferenceStore, token);
+            TokenScannerUtils.addTokenType(this,
+                    token,
+                    StringConverter.asString(tokenStyle.rgb),
+                    tokenStyle.isBold,
+                    tokenStyle.isItalic);
+        }
+    }
 
     
     public final void addTokenType(Keyword tokenIndex, org.eclipse.jface.text.rules.IToken token) {
@@ -355,7 +353,7 @@ public final class ClojureTokenScanner implements ITokenScanner, IPropertyChange
         Keyword keyword = PreferenceConstants.guessPreferenceKeyword(event.getProperty());
         if (PreferenceConstants.colorizableTokens.contains(keyword)) {
             IToken eclipseToken = parserTokenKeywordToJFaceToken.get(keyword);
-            utils.addTokenType(keyword, adaptToken(eclipseToken, event.getProperty(), event.getNewValue()));
+            TokenScannerUtils.addTokenType(this, keyword, adaptToken(eclipseToken, event.getProperty(), event.getNewValue()));
             clojureEditor.markDamagedAndRedraw();
         }
     }

--- a/ccw.core/src/java/ccw/editors/clojure/scanners/TokenScannerUtils.java
+++ b/ccw.core/src/java/ccw/editors/clojure/scanners/TokenScannerUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 Laurent Petit.
+ * Copyright (c) 2015 Laurent Petit.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,11 +7,13 @@
  *
  * Contributors: 
  *    Laurent PETIT - initial API and implementation
+ *    Andrea RICHIARDI - added readToken for ClojureCharRule
  *******************************************************************************/
 package ccw.editors.clojure.scanners;
 
 import org.eclipse.jface.resource.StringConverter;
 import org.eclipse.jface.text.TextAttribute;
+import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IToken;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
@@ -21,13 +23,7 @@ import clojure.lang.Keyword;
 
 
 public class TokenScannerUtils {
-	private ClojureTokenScanner scanner;
-//	private ColorRegistry colorCache;
 
-	public TokenScannerUtils(ClojureTokenScanner scanner) {
-		this.scanner = scanner;
-	}
-	
 	/**
      * Creates the data to feed an IToken.
      * @param rgb A color (RGB).
@@ -69,11 +65,117 @@ public class TokenScannerUtils {
 	 * @param isBold
 	 * @param isItalic
 	 */
-	public void addTokenType(Keyword tokenIndex, String rgb, Boolean isBold, Boolean isItalic) {
+	public static void addTokenType(ClojureTokenScanner scanner, Keyword tokenIndex, String rgb, Boolean isBold, Boolean isItalic) {
 		scanner.addTokenType(tokenIndex, createTokenData(rgb, isBold, isItalic));
 	}
 
-	public void addTokenType(Keyword tokenIndex, IToken token) {
+	public static void addTokenType(ClojureTokenScanner scanner, Keyword tokenIndex, IToken token) {
 		scanner.addTokenType(tokenIndex, token);
 	}
+
+    /**
+     * Reads a token, implementation adapted from
+     * <a href="https://github.com/clojure/clojure/commits/clojure-1.7.0">Clojure</a>.
+     * @param scanner A ICharacterScanner
+     * @param sb An already built StringBuilder
+     * @return A token string
+     */
+    private static String readToken(ICharacterScanner scanner, StringBuilder sb) {
+        for(; ;)
+        {
+            int ch = scanner.read();
+            if(ch == -1 || isWhitespace(ch) || isTerminatingMacro(ch))
+            {
+                scanner.unread();
+                return sb.toString();
+            }
+            sb.append((char) ch);
+        }
+    }
+
+    /**
+     * Reads a token, implementation adapted from
+     * <a href="https://github.com/clojure/clojure/commits/clojure-1.7.0">Clojure</a>.
+     * @param scanner A ICharacterScanner
+     * @return A token string
+     */
+    public static String readToken(ICharacterScanner scanner) {
+        StringBuilder sb = new StringBuilder();
+        return readToken(scanner, sb);
+    }
+
+    /**
+     * Reads a token, implementation adapted from
+     * <a href="https://github.com/clojure/clojure/commits/clojure-1.7.0">Clojure</a>.
+     * @param scanner A ICharacterScanner
+     * @param initch Init char
+     * @return A token string
+     */
+    public static String readToken(ICharacterScanner scanner, char initch) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(initch);
+        return readToken(scanner, sb);
+    }
+
+    /**
+     * Reads a Unicode char from a token, implementation adapted from
+     * <a href="https://github.com/clojure/clojure/commits/clojure-1.7.0">Clojure</a>.
+     * @param token The token
+     * @param offset An offset in the token
+     * @param length The length of the token
+     * @param base the base used for the decoding
+     * @return
+     */
+    public static int readUnicodeChar(String token, int offset, int length, int base) {
+        if(token.length() != offset + length)
+            throw new IllegalArgumentException("Invalid unicode character: \\" + token);
+        int uc = 0;
+        for(int i = offset; i < offset + length; ++i)
+            {
+            int d = Character.digit(token.charAt(i), base);
+            if(d == -1)
+                throw new IllegalArgumentException("Invalid digit: " + token.charAt(i));
+            uc = uc * base + d;
+            }
+        return (char) uc;
+    }
+
+    /**
+     * AR - Could have used paredit.clj/loc_utils definition of whitespace here but I guess this is faster.
+     * @param ch
+     * @return
+     */
+    public static boolean isWhitespace(int ch){
+        return Character.isWhitespace(ch) || ch == ',';
+    }
+
+    // AR - I am leaving the structure of clojure's source as it might be still useful
+    public static Character[] macroChars = new Character[256];
+    static {
+        macroChars['"'] = new Character('"');
+        macroChars[';'] = new Character(';');
+        macroChars['\''] = new Character('\'');
+        macroChars['@'] = new Character('@');
+        macroChars['^'] = new Character('^');
+        macroChars['`'] = new Character('`');
+        macroChars['~'] = new Character('~');
+        macroChars['('] = new Character('(');
+        macroChars[')'] = new Character(')');
+        macroChars['['] = new Character('[');
+        macroChars[']'] = new Character(']');
+        macroChars['{'] = new Character('{');
+        macroChars['}'] = new Character('}');
+        //  macroChars['|'] = new Character('|');
+        macroChars['\\'] = new Character('\\');
+        macroChars['%'] = new Character('%');
+        macroChars['#'] = new Character('#');
+    }
+
+    static private boolean isMacro(int ch){
+        return (ch < macroChars.length && macroChars[ch] != null);
+    }
+
+    static private boolean isTerminatingMacro(int ch){
+        return (ch != '#' && ch != '\'' && ch != '%' && isMacro(ch));
+    }
 }

--- a/ccw.core/src/java/ccw/editors/clojure/scanners/rules/ClojureCharRule.java
+++ b/ccw.core/src/java/ccw/editors/clojure/scanners/rules/ClojureCharRule.java
@@ -1,0 +1,92 @@
+package ccw.editors.clojure.scanners.rules;
+
+import org.eclipse.jface.text.rules.ICharacterScanner;
+import org.eclipse.jface.text.rules.IPredicateRule;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.Token;
+
+import ccw.editors.clojure.scanners.TokenScannerUtils;
+
+/**
+ * The Character rule, implementation adapted from
+ * <a href="https://github.com/clojure/clojure/commits/clojure-1.7.0">Clojure</a>.
+ * @author Andrea Richiardi
+ *
+ */
+public class ClojureCharRule implements IPredicateRule {
+    private final IToken tokenToReturn;
+    public ClojureCharRule(IToken tokenToReturn) {
+        this.tokenToReturn = tokenToReturn; 
+    }
+
+    public IToken evaluate(ICharacterScanner scanner, boolean resume) {
+        if (resume == true) {
+            throw new IllegalArgumentException("unhandled case when resume = true");
+        } else {
+            return evaluate(scanner);
+        }
+    }
+
+    public IToken getSuccessToken() {
+        return tokenToReturn;
+    }
+
+    @Override
+    public IToken evaluate(ICharacterScanner scanner) {
+        int readCharCount = 0;
+        
+        int ch = scanner.read();
+        readCharCount += 1;
+        
+        if(ch == ICharacterScanner.EOF) return undefined(scanner, readCharCount);
+        if ((char)ch != '\\') return undefined(scanner, readCharCount);
+        
+        String token = TokenScannerUtils.readToken(scanner);
+        readCharCount += token.length();
+        
+        if(token.length() == 1) {
+            char next = token.charAt(0);
+            if (Character.isDefined(next)) return getSuccessToken();
+            else return undefined(scanner, readCharCount);
+        }
+        else if(token.equals("newline"))
+            return getSuccessToken();
+        else if(token.equals("space"))
+            return getSuccessToken();
+        else if(token.equals("tab"))
+            return getSuccessToken();
+        else if(token.equals("backspace"))
+            return getSuccessToken();
+        else if(token.equals("formfeed"))
+            return getSuccessToken();
+        else if(token.equals("return"))
+            return getSuccessToken();
+        else if(token.startsWith("u")) {
+            char c = (char) TokenScannerUtils.readUnicodeChar(token, 1, 4, 16);
+            if(c >= '\uD800' && c <= '\uDFFF') // surrogate code unit?
+                return undefined(scanner, readCharCount);
+            return getSuccessToken();
+        } else if(token.startsWith("o")) {
+            int len = token.length() - 1;
+            if(len > 3)
+                return undefined(scanner, readCharCount);
+            int uc = TokenScannerUtils.readUnicodeChar(token, 1, len, 8);
+            if(uc > 0377)
+                return undefined(scanner, readCharCount);
+            return getSuccessToken();
+        }
+        return undefined(scanner, readCharCount);
+    }
+    
+    /**
+     * Returns Token.UNDEFINED and unreads a char.
+     * @param scanner
+     * @return Token.UNDEFINED
+     */
+    private IToken undefined(ICharacterScanner scanner, int charCountToUnread) {
+        for (int i = 0; i < charCountToUnread; i++) {
+            scanner.unread();
+        }
+        return Token.UNDEFINED;
+    }
+}

--- a/ccw.core/src/java/ccw/launching/EnhancedJavaLaunchDelegate.java
+++ b/ccw.core/src/java/ccw/launching/EnhancedJavaLaunchDelegate.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Laurent Petit and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: 
+ *    Laurent Petit - initial API and implementation
+ *******************************************************************************/
+package ccw.launching;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.jdt.launching.JavaLaunchDelegate;
+
+import ccw.CCWPlugin;
+import ccw.util.ClojureInvoker;
+
+/**
+ * Small enhancements over <code>JavaLaunchDelegate</code>.
+ * <ul>
+ * <li>Fix OS X not propagating environment variables: add additional PATHs to the PATH
+ * </ul>
+ * 
+ * @author laurentpetit
+ */
+public class EnhancedJavaLaunchDelegate extends JavaLaunchDelegate {
+
+	private final ClojureInvoker support = ClojureInvoker.newInvoker(
+            CCWPlugin.getDefault(),
+            "ccw.launching.enhanced-java-launch-delegate");
+
+	public static final String ID_JAVA_APPLICATION = "ccw.launching.enhanced-java";
+
+	@Override
+	public String[] getEnvironment(ILaunchConfiguration configuration) throws CoreException {
+		return (String[]) support._("get-environment", this, configuration);
+	}
+	
+	public String[] superGetEnvironment(ILaunchConfiguration configuration) throws CoreException {
+		return super.getEnvironment(configuration);
+	}
+
+}


### PR DESCRIPTION
By adapting parts of Clojure's 1.7 LispReader class, now CCW can correctly identify ```__clojure_char``` partitions.

This is not visible in the UI, but I was working on the folding and came out.
Given:
```(def letter-s \newline)```

Before (from the tracing):
```
Partition type: __clojure_char, offset: 721, length: 2
Text:
\n
---------------------------


Partition type: __dftl_partition_content_type, offset: 723, length: 9
Text:
ewline)
```

After:
```
Partition type: __clojure_char, offset: 721, length: 8
Text:
\newline
---------------------------


Partition type: __dftl_partition_content_type, offset: 729, length: 3
Text:
)
```

As a consequence now we could compile (statically) a customized content assist for __clojure_char partition with ```\newline```, ```\tab```, etc etc, plus hinting at ```\uXXXX```and ```\oYYY``` for unicode .
