### PR TITLE
Remove early get of IEventBroker

### DIFF
--- a/ccw.core/src/java/ccw/CCWPlugin.java
+++ b/ccw.core/src/java/ccw/CCWPlugin.java
@@ -346,22 +346,6 @@ public class CCWPlugin extends AbstractUIPlugin {
 								}
 
 								getNatureAdapter().start();
-								IEventBroker b = getEclipseContext().get(IEventBroker.class);
-								b.subscribe(UIEvents.UILifeCycle.PERSPECTIVE_OPENED, null, new EventHandler() {
-									@Override public void handleEvent(Event event) {
-										System.out.println("Perspective Opened:" + event.getProperty(UIEvents.UILabel.LABEL));
-									}
-								}, false);
-								b.subscribe(UIEvents.Perspective.TOPIC_ALL, null, new EventHandler() {
-									@Override public void handleEvent(Event event) {
-										System.out.println("Perspective event:" + event);
-									}
-								}, false);
-								b.subscribe(UIEvents.UILifeCycle.ACTIVATE, null, new EventHandler() {
-									@Override public void handleEvent(Event event) {
-										System.out.println("MPart Activated:" + event);
-									}
-								}, false);
 							}
 
 						}).start();


### PR DESCRIPTION
Hello Laurent, a fix for master:

```By getting IEventBroker too early in CCWPlugin.start(), an "Unable to process "EventBroker.logger"
Exception was triggered. This patch solves the problem (but also removes the custom event logging).```

If you want to still log the events, maybe we need to find another place to hook the listeners...