### PR TITLE
fix(doc): address nits in installation and keyboard shortcuts

### DIFF
--- a/doc/documentation.adoc
+++ b/doc/documentation.adoc
@@ -84,7 +84,7 @@ any Eclipse packaging which includes JDT (Java Development Tools) will work:  "E
 Eclipse 3 (Indigo, Eclipse 3.8.x) is no longer supported, but you can still install a version < 0.30 of Counterclockwise
 ====
 
-Counterclockwise is available via the Eclipse Marketplace Client: search for `Counterclockwise`
+Counterclockwise is available via the Eclipse Marketplace Client: search for `Counterclockwise` or `Clojure`
 
 
 You may now want to <<first-project,create your first project>> or <<open-project,open an existing project>>. +

--- a/doc/keyboard-shortcuts.adoc
+++ b/doc/keyboard-shortcuts.adoc
@@ -265,7 +265,7 @@ In addition to the features of the Default Structural Editing mode, this mode do
 
 Note: You'll only feel "at home" in this mode if you know the following commands
 
-==== Reindend line
+==== Reindent line
 Reindent the line properly
 
 [cols="1", options="header"]


### PR DESCRIPTION
In Eclipse IDE for Java Developers (Version: Mars.1 Release (4.5.1), Build id:
20150924-1200) ccw doesn't show up when I searched for "Counterclockwise." Add
a note to the docs to search for either "Counterclockwise" or "Clojure." Also
fix a typo in the keyboard shortcut docs (Reindend -> Reindent).